### PR TITLE
Add contents caching and virtual filesystem support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,12 +18,14 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php-version }}
+          # Ensure ext-opcache is installed for running tests against.
+          extensions: ':opcache'
 
       - name: Install Composer dependencies
         run: composer install
 
       - name: Run tests
-        run: vendor/bin/phpunit
+        run: php -d opcache.enable=On -d opcache.enable_cli=On vendor/bin/phpunit
 
   phpstan:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       # Check out the repository under $GITHUB_WORKSPACE, so this job can access it.
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Use PHP ${{ matrix.php-version }}
         uses: shivammathur/setup-php@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
         with:
           php-version: ${{ matrix.php-version }}
           # Ensure ext-opcache is installed for running tests against.
-          extensions: ':opcache'
+          extensions: 'opcache'
 
       - name: Install Composer dependencies
         run: composer install

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require": {
         "php": ">=8.1",
-        "asmblah/php-code-shift": "dev-main as v0.1.16",
+        "asmblah/php-code-shift": "^0.1",
         "nytris/nytris": "^0.1",
         "psr/cache": "^1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     },
     "require": {
         "php": ">=8.1",
-        "asmblah/php-code-shift": "^0.1",
+        "asmblah/php-code-shift": "dev-main as v0.1.16",
         "nytris/nytris": "^0.1",
         "psr/cache": "^1.0"
     },
@@ -22,7 +22,8 @@
         "mockery/mockery": "1.6.11",
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-mockery": "^1.1",
-        "phpunit/phpunit": "^10.2"
+        "phpunit/phpunit": "^10.2",
+        "symfony/cache": "^5.4"
     },
     "config": {
         "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -8,20 +8,20 @@
     "packages": [
         {
             "name": "asmblah/php-code-shift",
-            "version": "v0.1.15",
+            "version": "v0.1.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/asmblah/php-code-shift.git",
-                "reference": "aefd687c615c9050c1185db1f2539699f9ab1ba5"
+                "reference": "9dcff0fae2e76dfa71b0e2d4a35d55783c47f5ac"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/asmblah/php-code-shift/zipball/aefd687c615c9050c1185db1f2539699f9ab1ba5",
-                "reference": "aefd687c615c9050c1185db1f2539699f9ab1ba5",
+                "url": "https://api.github.com/repos/asmblah/php-code-shift/zipball/9dcff0fae2e76dfa71b0e2d4a35d55783c47f5ac",
+                "reference": "9dcff0fae2e76dfa71b0e2d4a35d55783c47f5ac",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^4.16",
+                "nikic/php-parser": "^4.18 || ^5.0",
                 "nytris/nytris": "^0.1",
                 "php": ">=8.1",
                 "psr/log": "^1|^2|^3",
@@ -48,31 +48,33 @@
             ],
             "support": {
                 "issues": "https://github.com/asmblah/php-code-shift/issues",
-                "source": "https://github.com/asmblah/php-code-shift/tree/v0.1.15"
+                "source": "https://github.com/asmblah/php-code-shift/tree/v0.1.16"
             },
-            "time": "2024-08-21T01:41:43+00:00"
+            "time": "2024-09-11T06:42:56+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.19.1",
+            "version": "v5.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "4e1b88d21c69391150ace211e9eaf05810858d0b"
+                "reference": "683130c2ff8c2739f4822ff7ac5c873ec529abd1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/4e1b88d21c69391150ace211e9eaf05810858d0b",
-                "reference": "4e1b88d21c69391150ace211e9eaf05810858d0b",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/683130c2ff8c2739f4822ff7ac5c873ec529abd1",
+                "reference": "683130c2ff8c2739f4822ff7ac5c873ec529abd1",
                 "shasum": ""
             },
             "require": {
+                "ext-ctype": "*",
+                "ext-json": "*",
                 "ext-tokenizer": "*",
-                "php": ">=7.1"
+                "php": ">=7.4"
             },
             "require-dev": {
                 "ircmaxell/php-yacc": "^0.0.7",
-                "phpunit/phpunit": "^6.5 || ^7.0 || ^8.0 || ^9.0"
+                "phpunit/phpunit": "^9.0"
             },
             "bin": [
                 "bin/php-parse"
@@ -80,7 +82,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "4.9-dev"
+                    "dev-master": "5.0-dev"
                 }
             },
             "autoload": {
@@ -104,9 +106,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.19.1"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.1.0"
             },
-            "time": "2024-03-17T08:10:35+00:00"
+            "time": "2024-07-01T20:03:41+00:00"
         },
         {
             "name": "nytris/nytris",
@@ -201,16 +203,16 @@
         },
         {
             "name": "psr/log",
-            "version": "3.0.0",
+            "version": "3.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001"
+                "reference": "79dff0b268932c640297f5208d6298f71855c03e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/fe5ea303b0887d5caefd3d431c3e61ad47037001",
-                "reference": "fe5ea303b0887d5caefd3d431c3e61ad47037001",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/79dff0b268932c640297f5208d6298f71855c03e",
+                "reference": "79dff0b268932c640297f5208d6298f71855c03e",
                 "shasum": ""
             },
             "require": {
@@ -245,9 +247,9 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/3.0.0"
+                "source": "https://github.com/php-fig/log/tree/3.0.1"
             },
-            "time": "2021-07-14T16:46:02+00:00"
+            "time": "2024-08-21T13:31:24+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -318,20 +320,20 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.30.0",
+            "version": "v1.31.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "0424dff1c58f028c451efff2045f5d92410bd540"
+                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/0424dff1c58f028c451efff2045f5d92410bd540",
-                "reference": "0424dff1c58f028c451efff2045f5d92410bd540",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.2"
             },
             "provide": {
                 "ext-ctype": "*"
@@ -377,7 +379,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.30.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.31.0"
             },
             "funding": [
                 {
@@ -393,24 +395,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T15:07:36+00:00"
+            "time": "2024-09-09T11:45:10+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.30.0",
+            "version": "v1.31.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "fd22ab50000ef01661e2a31d850ebaa297f8e03c"
+                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/fd22ab50000ef01661e2a31d850ebaa297f8e03c",
-                "reference": "fd22ab50000ef01661e2a31d850ebaa297f8e03c",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/85181ba99b2345b0ef10ce42ecac37612d9fd341",
+                "reference": "85181ba99b2345b0ef10ce42ecac37612d9fd341",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.2"
             },
             "provide": {
                 "ext-mbstring": "*"
@@ -457,7 +459,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.30.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.31.0"
             },
             "funding": [
                 {
@@ -473,24 +475,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-19T12:30:46+00:00"
+            "time": "2024-09-09T11:45:10+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.30.0",
+            "version": "v1.31.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "77fa7995ac1b21ab60769b7323d600a991a90433"
+                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/77fa7995ac1b21ab60769b7323d600a991a90433",
-                "reference": "77fa7995ac1b21ab60769b7323d600a991a90433",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
+                "reference": "60328e362d4c2c802a54fcbf04f9d3fb892b4cf8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1"
+                "php": ">=7.2"
             },
             "type": "library",
             "extra": {
@@ -537,7 +539,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.30.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.31.0"
             },
             "funding": [
                 {
@@ -553,7 +555,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-05-31T15:07:36+00:00"
+            "time": "2024-09-09T11:45:10+00:00"
         }
     ],
     "packages-dev": [
@@ -871,16 +873,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.11.11",
+            "version": "1.12.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "707c2aed5d8d0075666e673a5e71440c1d01a5a3"
+                "reference": "0fcbf194ab63d8159bb70d9aa3e1350051632009"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/707c2aed5d8d0075666e673a5e71440c1d01a5a3",
-                "reference": "707c2aed5d8d0075666e673a5e71440c1d01a5a3",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/0fcbf194ab63d8159bb70d9aa3e1350051632009",
+                "reference": "0fcbf194ab63d8159bb70d9aa3e1350051632009",
                 "shasum": ""
             },
             "require": {
@@ -925,7 +927,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-08-19T14:37:29+00:00"
+            "time": "2024-09-09T08:10:35+00:00"
         },
         {
             "name": "phpstan/phpstan-mockery",
@@ -979,32 +981,32 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "10.1.15",
+            "version": "10.1.16",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "5da8b1728acd1e6ffdf2ff32ffbdfd04307f26ae"
+                "reference": "7e308268858ed6baedc8704a304727d20bc07c77"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/5da8b1728acd1e6ffdf2ff32ffbdfd04307f26ae",
-                "reference": "5da8b1728acd1e6ffdf2ff32ffbdfd04307f26ae",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/7e308268858ed6baedc8704a304727d20bc07c77",
+                "reference": "7e308268858ed6baedc8704a304727d20bc07c77",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.18 || ^5.0",
+                "nikic/php-parser": "^4.19.1 || ^5.1.0",
                 "php": ">=8.1",
-                "phpunit/php-file-iterator": "^4.0",
-                "phpunit/php-text-template": "^3.0",
-                "sebastian/code-unit-reverse-lookup": "^3.0",
-                "sebastian/complexity": "^3.0",
-                "sebastian/environment": "^6.0",
-                "sebastian/lines-of-code": "^2.0",
-                "sebastian/version": "^4.0",
-                "theseer/tokenizer": "^1.2.0"
+                "phpunit/php-file-iterator": "^4.1.0",
+                "phpunit/php-text-template": "^3.0.1",
+                "sebastian/code-unit-reverse-lookup": "^3.0.0",
+                "sebastian/complexity": "^3.2.0",
+                "sebastian/environment": "^6.1.0",
+                "sebastian/lines-of-code": "^2.0.2",
+                "sebastian/version": "^4.0.1",
+                "theseer/tokenizer": "^1.2.3"
             },
             "require-dev": {
                 "phpunit/phpunit": "^10.1"
@@ -1016,7 +1018,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "10.1-dev"
+                    "dev-main": "10.1.x-dev"
                 }
             },
             "autoload": {
@@ -1045,7 +1047,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.15"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/10.1.16"
             },
             "funding": [
                 {
@@ -1053,7 +1055,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-06-29T08:25:15+00:00"
+            "time": "2024-08-22T04:31:57+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -1300,16 +1302,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.30",
+            "version": "10.5.33",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "b15524febac0153876b4ba9aab3326c2ee94c897"
+                "reference": "4def7a9cda75af9c2bc179ed53a8e41313e7f7cf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/b15524febac0153876b4ba9aab3326c2ee94c897",
-                "reference": "b15524febac0153876b4ba9aab3326c2ee94c897",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/4def7a9cda75af9c2bc179ed53a8e41313e7f7cf",
+                "reference": "4def7a9cda75af9c2bc179ed53a8e41313e7f7cf",
                 "shasum": ""
             },
             "require": {
@@ -1323,7 +1325,7 @@
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
                 "php": ">=8.1",
-                "phpunit/php-code-coverage": "^10.1.15",
+                "phpunit/php-code-coverage": "^10.1.16",
                 "phpunit/php-file-iterator": "^4.1.0",
                 "phpunit/php-invoker": "^4.0.0",
                 "phpunit/php-text-template": "^3.0.1",
@@ -1381,7 +1383,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.30"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.33"
             },
             "funding": [
                 {
@@ -1397,7 +1399,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-08-13T06:09:37+00:00"
+            "time": "2024-09-09T06:06:56+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/composer.lock
+++ b/composer.lock
@@ -4,20 +4,20 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fe4616a799d0fe94fda7f5a0ee4e51af",
+    "content-hash": "f4ad597bf45ed77f629671899d02f343",
     "packages": [
         {
             "name": "asmblah/php-code-shift",
-            "version": "v0.1.16",
+            "version": "dev-main",
             "source": {
                 "type": "git",
                 "url": "https://github.com/asmblah/php-code-shift.git",
-                "reference": "9dcff0fae2e76dfa71b0e2d4a35d55783c47f5ac"
+                "reference": "c30ef6b4531300c8ff9084b54a85b6b2db2e267c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/asmblah/php-code-shift/zipball/9dcff0fae2e76dfa71b0e2d4a35d55783c47f5ac",
-                "reference": "9dcff0fae2e76dfa71b0e2d4a35d55783c47f5ac",
+                "url": "https://api.github.com/repos/asmblah/php-code-shift/zipball/c30ef6b4531300c8ff9084b54a85b6b2db2e267c",
+                "reference": "c30ef6b4531300c8ff9084b54a85b6b2db2e267c",
                 "shasum": ""
             },
             "require": {
@@ -33,6 +33,7 @@
                 "phpstan/phpstan-mockery": "^1.1",
                 "phpunit/phpunit": "^10.2"
             },
+            "default-branch": true,
             "type": "project",
             "autoload": {
                 "files": [
@@ -48,22 +49,22 @@
             ],
             "support": {
                 "issues": "https://github.com/asmblah/php-code-shift/issues",
-                "source": "https://github.com/asmblah/php-code-shift/tree/v0.1.16"
+                "source": "https://github.com/asmblah/php-code-shift/tree/main"
             },
-            "time": "2024-09-11T06:42:56+00:00"
+            "time": "2024-09-21T08:30:42+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.1.0",
+            "version": "v5.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "683130c2ff8c2739f4822ff7ac5c873ec529abd1"
+                "reference": "23c79fbbfb725fb92af9bcf41065c8e9a0d49ddb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/683130c2ff8c2739f4822ff7ac5c873ec529abd1",
-                "reference": "683130c2ff8c2739f4822ff7ac5c873ec529abd1",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/23c79fbbfb725fb92af9bcf41065c8e9a0d49ddb",
+                "reference": "23c79fbbfb725fb92af9bcf41065c8e9a0d49ddb",
                 "shasum": ""
             },
             "require": {
@@ -106,9 +107,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.1.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.2.0"
             },
-            "time": "2024-07-01T20:03:41+00:00"
+            "time": "2024-09-15T16:40:33+00:00"
         },
         {
             "name": "nytris/nytris",
@@ -203,16 +204,16 @@
         },
         {
             "name": "psr/log",
-            "version": "3.0.1",
+            "version": "3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/log.git",
-                "reference": "79dff0b268932c640297f5208d6298f71855c03e"
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/log/zipball/79dff0b268932c640297f5208d6298f71855c03e",
-                "reference": "79dff0b268932c640297f5208d6298f71855c03e",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
+                "reference": "f16e1d5863e37f8d8c2a01719f5b34baa2b714d3",
                 "shasum": ""
             },
             "require": {
@@ -247,22 +248,22 @@
                 "psr-3"
             ],
             "support": {
-                "source": "https://github.com/php-fig/log/tree/3.0.1"
+                "source": "https://github.com/php-fig/log/tree/3.0.2"
             },
-            "time": "2024-08-21T13:31:24+00:00"
+            "time": "2024-09-11T13:17:53+00:00"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v5.4.41",
+            "version": "v5.4.44",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "6d29dd9340b372fa603f04e6df4dd76bb808591e"
+                "reference": "76c3818964e9d32be3862c9318ae3ba9aa280ddc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/6d29dd9340b372fa603f04e6df4dd76bb808591e",
-                "reference": "6d29dd9340b372fa603f04e6df4dd76bb808591e",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/76c3818964e9d32be3862c9318ae3ba9aa280ddc",
+                "reference": "76c3818964e9d32be3862c9318ae3ba9aa280ddc",
                 "shasum": ""
             },
             "require": {
@@ -300,7 +301,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v5.4.41"
+                "source": "https://github.com/symfony/filesystem/tree/v5.4.44"
             },
             "funding": [
                 {
@@ -316,7 +317,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-06-28T09:36:24+00:00"
+            "time": "2024-09-16T14:52:48+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -873,16 +874,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.3",
+            "version": "1.12.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "0fcbf194ab63d8159bb70d9aa3e1350051632009"
+                "reference": "ffa517cb918591b93acc9b95c0bebdcd0e4538bd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/0fcbf194ab63d8159bb70d9aa3e1350051632009",
-                "reference": "0fcbf194ab63d8159bb70d9aa3e1350051632009",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/ffa517cb918591b93acc9b95c0bebdcd0e4538bd",
+                "reference": "ffa517cb918591b93acc9b95c0bebdcd0e4538bd",
                 "shasum": ""
             },
             "require": {
@@ -927,32 +928,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-09-09T08:10:35+00:00"
+            "time": "2024-09-19T07:58:01+00:00"
         },
         {
             "name": "phpstan/phpstan-mockery",
-            "version": "1.1.2",
+            "version": "1.1.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan-mockery.git",
-                "reference": "88ae85931768efd3aaf3cce4cb9cb54c4d157d03"
+                "reference": "98cac6e256b4ee60fdeb26a7dd81bb271b454e80"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan-mockery/zipball/88ae85931768efd3aaf3cce4cb9cb54c4d157d03",
-                "reference": "88ae85931768efd3aaf3cce4cb9cb54c4d157d03",
+                "url": "https://api.github.com/repos/phpstan/phpstan-mockery/zipball/98cac6e256b4ee60fdeb26a7dd81bb271b454e80",
+                "reference": "98cac6e256b4ee60fdeb26a7dd81bb271b454e80",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2 || ^8.0",
-                "phpstan/phpstan": "^1.10"
+                "phpstan/phpstan": "^1.12"
             },
             "require-dev": {
-                "mockery/mockery": "^1.2.4",
+                "mockery/mockery": "^1.6.11",
                 "nikic/php-parser": "^4.13.0",
                 "php-parallel-lint/php-parallel-lint": "^1.2",
-                "phpstan/phpstan-phpunit": "^1.0",
-                "phpstan/phpstan-strict-rules": "^1.0",
+                "phpstan/phpstan-phpunit": "^1.4",
+                "phpstan/phpstan-strict-rules": "^1.6",
                 "phpunit/phpunit": "^9.5"
             },
             "type": "phpstan-extension",
@@ -975,9 +976,9 @@
             "description": "PHPStan Mockery extension",
             "support": {
                 "issues": "https://github.com/phpstan/phpstan-mockery/issues",
-                "source": "https://github.com/phpstan/phpstan-mockery/tree/1.1.2"
+                "source": "https://github.com/phpstan/phpstan-mockery/tree/1.1.3"
             },
-            "time": "2024-01-10T13:50:05+00:00"
+            "time": "2024-09-11T15:47:29+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -1302,16 +1303,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "10.5.33",
+            "version": "10.5.35",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "4def7a9cda75af9c2bc179ed53a8e41313e7f7cf"
+                "reference": "7ac8b4e63f456046dcb4c9787da9382831a1874b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/4def7a9cda75af9c2bc179ed53a8e41313e7f7cf",
-                "reference": "4def7a9cda75af9c2bc179ed53a8e41313e7f7cf",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/7ac8b4e63f456046dcb4c9787da9382831a1874b",
+                "reference": "7ac8b4e63f456046dcb4c9787da9382831a1874b",
                 "shasum": ""
             },
             "require": {
@@ -1383,7 +1384,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.33"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/10.5.35"
             },
             "funding": [
                 {
@@ -1399,7 +1400,60 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T06:06:56+00:00"
+            "time": "2024-09-19T10:52:21+00:00"
+        },
+        {
+            "name": "psr/container",
+            "version": "2.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/container.git",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.4.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Container\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common Container Interface (PHP FIG PSR-11)",
+            "homepage": "https://github.com/php-fig/container",
+            "keywords": [
+                "PSR-11",
+                "container",
+                "container-interface",
+                "container-interop",
+                "psr"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/container/issues",
+                "source": "https://github.com/php-fig/container/tree/2.0.2"
+            },
+            "time": "2021-11-05T16:47:00+00:00"
         },
         {
             "name": "sebastian/cli-parser",
@@ -2318,6 +2372,485 @@
             "time": "2023-02-07T11:34:05+00:00"
         },
         {
+            "name": "symfony/cache",
+            "version": "v5.4.44",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/cache.git",
+                "reference": "4b3e7bf157b8b5a010865701d9106b5f0a9c99a8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/cache/zipball/4b3e7bf157b8b5a010865701d9106b5f0a9c99a8",
+                "reference": "4b3e7bf157b8b5a010865701d9106b5f0a9c99a8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "psr/cache": "^1.0|^2.0",
+                "psr/log": "^1.1|^2|^3",
+                "symfony/cache-contracts": "^1.1.7|^2",
+                "symfony/deprecation-contracts": "^2.1|^3",
+                "symfony/polyfill-php73": "^1.9",
+                "symfony/polyfill-php80": "^1.16",
+                "symfony/service-contracts": "^1.1|^2|^3",
+                "symfony/var-exporter": "^4.4|^5.0|^6.0"
+            },
+            "conflict": {
+                "doctrine/dbal": "<2.13.1",
+                "symfony/dependency-injection": "<4.4",
+                "symfony/http-kernel": "<4.4",
+                "symfony/var-dumper": "<4.4"
+            },
+            "provide": {
+                "psr/cache-implementation": "1.0|2.0",
+                "psr/simple-cache-implementation": "1.0|2.0",
+                "symfony/cache-implementation": "1.0|2.0"
+            },
+            "require-dev": {
+                "cache/integration-tests": "dev-master",
+                "doctrine/cache": "^1.6|^2.0",
+                "doctrine/dbal": "^2.13.1|^3|^4",
+                "predis/predis": "^1.1|^2.0",
+                "psr/simple-cache": "^1.0|^2.0",
+                "symfony/config": "^4.4|^5.0|^6.0",
+                "symfony/dependency-injection": "^4.4|^5.0|^6.0",
+                "symfony/filesystem": "^4.4|^5.0|^6.0",
+                "symfony/http-kernel": "^4.4|^5.0|^6.0",
+                "symfony/messenger": "^4.4|^5.0|^6.0",
+                "symfony/var-dumper": "^4.4|^5.0|^6.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Cache\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Provides extended PSR-6, PSR-16 (and tags) implementations",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "caching",
+                "psr6"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/cache/tree/v5.4.44"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-13T16:57:39+00:00"
+        },
+        {
+            "name": "symfony/cache-contracts",
+            "version": "v2.5.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/cache-contracts.git",
+                "reference": "fee6db04d913094e2fb55ff8e7db5685a8134463"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/cache-contracts/zipball/fee6db04d913094e2fb55ff8e7db5685a8134463",
+                "reference": "fee6db04d913094e2fb55ff8e7db5685a8134463",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2.5",
+                "psr/cache": "^1.0|^2.0|^3.0"
+            },
+            "suggest": {
+                "symfony/cache-implementation": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "2.5-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Cache\\": ""
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to caching",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/cache-contracts/tree/v2.5.3"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-01-23T13:51:25+00:00"
+        },
+        {
+            "name": "symfony/deprecation-contracts",
+            "version": "v3.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/deprecation-contracts.git",
+                "reference": "0e0d29ce1f20deffb4ab1b016a7257c4f1e789a1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/0e0d29ce1f20deffb4ab1b016a7257c4f1e789a1",
+                "reference": "0e0d29ce1f20deffb4ab1b016a7257c4f1e789a1",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.5-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "function.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "A generic function and convention to trigger deprecation notices",
+            "homepage": "https://symfony.com",
+            "support": {
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-04-18T09:32:20+00:00"
+        },
+        {
+            "name": "symfony/polyfill-php73",
+            "version": "v1.31.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-php73.git",
+                "reference": "0f68c03565dcaaf25a890667542e8bd75fe7e5bb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-php73/zipball/0f68c03565dcaaf25a890667542e8bd75fe7e5bb",
+                "reference": "0f68c03565dcaaf25a890667542e8bd75fe7e5bb",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.2"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "name": "symfony/polyfill",
+                    "url": "https://github.com/symfony/polyfill"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ],
+                "psr-4": {
+                    "Symfony\\Polyfill\\Php73\\": ""
+                },
+                "classmap": [
+                    "Resources/stubs"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill backporting some PHP 7.3+ features to lower PHP versions",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/polyfill-php73/tree/v1.31.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-09-09T11:45:10+00:00"
+        },
+        {
+            "name": "symfony/service-contracts",
+            "version": "v3.5.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/service-contracts.git",
+                "reference": "bd1d9e59a81d8fa4acdcea3f617c581f7475a80f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/bd1d9e59a81d8fa4acdcea3f617c581f7475a80f",
+                "reference": "bd1d9e59a81d8fa4acdcea3f617c581f7475a80f",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "psr/container": "^1.1|^2.0",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "conflict": {
+                "ext-psr": "<1.1|>=2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "3.5-dev"
+                },
+                "thanks": {
+                    "name": "symfony/contracts",
+                    "url": "https://github.com/symfony/contracts"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Contracts\\Service\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Test/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Generic abstractions related to writing services",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "abstractions",
+                "contracts",
+                "decoupling",
+                "interfaces",
+                "interoperability",
+                "standards"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/service-contracts/tree/v3.5.0"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-04-18T09:32:20+00:00"
+        },
+        {
+            "name": "symfony/var-exporter",
+            "version": "v6.4.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/var-exporter.git",
+                "reference": "f9a060622e0d93777b7f8687ec4860191e16802e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/var-exporter/zipball/f9a060622e0d93777b7f8687ec4860191e16802e",
+                "reference": "f9a060622e0d93777b7f8687ec4860191e16802e",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1",
+                "symfony/deprecation-contracts": "^2.5|^3"
+            },
+            "require-dev": {
+                "symfony/property-access": "^6.4|^7.0",
+                "symfony/serializer": "^6.4|^7.0",
+                "symfony/var-dumper": "^5.4|^6.0|^7.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\VarExporter\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Allows exporting any serializable PHP data structure to plain PHP code",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "clone",
+                "construct",
+                "export",
+                "hydrate",
+                "instantiate",
+                "lazy-loading",
+                "proxy",
+                "serialize"
+            ],
+            "support": {
+                "source": "https://github.com/symfony/var-exporter/tree/v6.4.9"
+            },
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-06-24T15:53:56+00:00"
+        },
+        {
             "name": "theseer/tokenizer",
             "version": "1.2.3",
             "source": {
@@ -2368,9 +2901,18 @@
             "time": "2024-03-03T12:36:25+00:00"
         }
     ],
-    "aliases": [],
+    "aliases": [
+        {
+            "package": "asmblah/php-code-shift",
+            "version": "dev-main",
+            "alias": "v0.1.16",
+            "alias_normalized": "0.1.16.0"
+        }
+    ],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "asmblah/php-code-shift": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/composer.lock
+++ b/composer.lock
@@ -12,12 +12,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/asmblah/php-code-shift.git",
-                "reference": "c30ef6b4531300c8ff9084b54a85b6b2db2e267c"
+                "reference": "bd0cb9685dc13d673e832078bc32240950fe1394"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/asmblah/php-code-shift/zipball/c30ef6b4531300c8ff9084b54a85b6b2db2e267c",
-                "reference": "c30ef6b4531300c8ff9084b54a85b6b2db2e267c",
+                "url": "https://api.github.com/repos/asmblah/php-code-shift/zipball/bd0cb9685dc13d673e832078bc32240950fe1394",
+                "reference": "bd0cb9685dc13d673e832078bc32240950fe1394",
                 "shasum": ""
             },
             "require": {
@@ -49,22 +49,22 @@
             ],
             "support": {
                 "issues": "https://github.com/asmblah/php-code-shift/issues",
-                "source": "https://github.com/asmblah/php-code-shift/tree/main"
+                "source": "https://github.com/asmblah/php-code-shift/tree/v0.1.17"
             },
-            "time": "2024-09-21T08:30:42+00:00"
+            "time": "2024-10-07T00:56:47+00:00"
         },
         {
             "name": "nikic/php-parser",
-            "version": "v5.2.0",
+            "version": "v5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "23c79fbbfb725fb92af9bcf41065c8e9a0d49ddb"
+                "reference": "3abf7425cd284141dc5d8d14a9ee444de3345d1a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/23c79fbbfb725fb92af9bcf41065c8e9a0d49ddb",
-                "reference": "23c79fbbfb725fb92af9bcf41065c8e9a0d49ddb",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/3abf7425cd284141dc5d8d14a9ee444de3345d1a",
+                "reference": "3abf7425cd284141dc5d8d14a9ee444de3345d1a",
                 "shasum": ""
             },
             "require": {
@@ -107,9 +107,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v5.2.0"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v5.3.0"
             },
-            "time": "2024-09-15T16:40:33+00:00"
+            "time": "2024-09-29T13:56:26+00:00"
         },
         {
             "name": "nytris/nytris",
@@ -874,16 +874,16 @@
         },
         {
             "name": "phpstan/phpstan",
-            "version": "1.12.4",
+            "version": "1.12.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpstan/phpstan.git",
-                "reference": "ffa517cb918591b93acc9b95c0bebdcd0e4538bd"
+                "reference": "dc4d2f145a88ea7141ae698effd64d9df46527ae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/ffa517cb918591b93acc9b95c0bebdcd0e4538bd",
-                "reference": "ffa517cb918591b93acc9b95c0bebdcd0e4538bd",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/dc4d2f145a88ea7141ae698effd64d9df46527ae",
+                "reference": "dc4d2f145a88ea7141ae698effd64d9df46527ae",
                 "shasum": ""
             },
             "require": {
@@ -928,7 +928,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-09-19T07:58:01+00:00"
+            "time": "2024-10-06T15:03:59+00:00"
         },
         {
             "name": "phpstan/phpstan-mockery",

--- a/composer.lock
+++ b/composer.lock
@@ -4,11 +4,11 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f4ad597bf45ed77f629671899d02f343",
+    "content-hash": "52fddbfab9a119822a6f60255006d3c8",
     "packages": [
         {
             "name": "asmblah/php-code-shift",
-            "version": "dev-main",
+            "version": "v0.1.17",
             "source": {
                 "type": "git",
                 "url": "https://github.com/asmblah/php-code-shift.git",
@@ -33,7 +33,6 @@
                 "phpstan/phpstan-mockery": "^1.1",
                 "phpunit/phpunit": "^10.2"
             },
-            "default-branch": true,
             "type": "project",
             "autoload": {
                 "files": [
@@ -2901,18 +2900,9 @@
             "time": "2024-03-03T12:36:25+00:00"
         }
     ],
-    "aliases": [
-        {
-            "package": "asmblah/php-code-shift",
-            "version": "dev-main",
-            "alias": "v0.1.16",
-            "alias_normalized": "0.1.16.0"
-        }
-    ],
+    "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {
-        "asmblah/php-code-shift": 20
-    },
+    "stability-flags": [],
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/src/Boost.php
+++ b/src/Boost.php
@@ -87,7 +87,19 @@ class Boost implements BoostInterface
          * In virtual-filesystem mode, the cache is write-allocate with no write-through
          * to the next stream handler in the chain (usually the original one, which persists to disk).
          */
-        bool $asVirtualFilesystem = false
+        bool $asVirtualFilesystem = false,
+        /**
+         * Read-only cache pool from which to preload the realpath cache.
+         *
+         * Set to null to disable preloading from a PSR cache.
+         */
+        ?CacheItemPoolInterface $realpathPreloadCachePool = null,
+        /**
+         * Read-only cache pool from which to preload the stat cache.
+         *
+         * Set to null to disable preloading from a PSR cache.
+         */
+        ?CacheItemPoolInterface $statPreloadCachePool = null
     ) {
         $this->hookBuiltinFunctionsFilter = match ($hookBuiltinFunctions) {
             true => new FileFilter('**'),
@@ -103,7 +115,9 @@ class Boost implements BoostInterface
 
         $this->fsCache = $fsCache ?? new FsCache(
             new FsCacheFactory($environment, $library->getCanonicaliser()),
+            $realpathPreloadCachePool,
             $realpathCachePool,
+            $statPreloadCachePool,
             $statCachePool,
             $contentsCache,
             $realpathCacheKey,
@@ -112,6 +126,22 @@ class Boost implements BoostInterface
             $pathFilter,
             $asVirtualFilesystem
         );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getInMemoryRealpathEntryCache(): array
+    {
+        return $this->fsCache->getInMemoryRealpathEntryCache();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getInMemoryStatEntryCache(): array
+    {
+        return $this->fsCache->getInMemoryStatEntryCache();
     }
 
     /**

--- a/src/Boost.php
+++ b/src/Boost.php
@@ -17,6 +17,7 @@ use Asmblah\PhpCodeShift\CodeShift;
 use Asmblah\PhpCodeShift\CodeShiftInterface;
 use Asmblah\PhpCodeShift\Shifter\Filter\FileFilter;
 use Asmblah\PhpCodeShift\Shifter\Filter\FileFilterInterface;
+use Nytris\Boost\Environment\Environment;
 use Nytris\Boost\FsCache\Canonicaliser;
 use Nytris\Boost\FsCache\Contents\ContentsCacheInterface;
 use Nytris\Boost\FsCache\FsCache;
@@ -72,12 +73,12 @@ class Boost implements BoostInterface
         /**
          * Filter for which file paths to cache in the realpath, stat and contents caches.
          */
-        FileFilterInterface $pathFilter = new FileFilter('*')
+        FileFilterInterface $pathFilter = new FileFilter('**')
     ) {
         $this->codeShift = $codeShift ?? new CodeShift();
         $this->fsCache = $fsCache ?? new FsCache(
             $this->codeShift,
-            new FsCacheFactory(new Canonicaliser()),
+            new FsCacheFactory(new Canonicaliser(new Environment())),
             $realpathCachePool,
             $statCachePool,
             $contentsCache,

--- a/src/BoostInterface.php
+++ b/src/BoostInterface.php
@@ -28,6 +28,13 @@ interface BoostInterface
     public function install(): void;
 
     /**
+     * Clears the realpath and stat caches.
+     *
+     * Note that this does not affect the contents cache.
+     */
+    public function invalidateCaches(): void;
+
+    /**
      * Uninstalls Nytris Boost.
      */
     public function uninstall(): void;

--- a/src/BoostInterface.php
+++ b/src/BoostInterface.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Nytris\Boost;
 
+use Nytris\Boost\Library\LibraryInterface;
+
 /**
  * Interface BoostInterface.
  *
@@ -22,6 +24,11 @@ namespace Nytris\Boost;
  */
 interface BoostInterface
 {
+    /**
+     * Fetches the library installation for this Boost instance.
+     */
+    public function getLibrary(): LibraryInterface;
+
     /**
      * Installs Nytris Boost.
      */

--- a/src/BoostInterface.php
+++ b/src/BoostInterface.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Nytris\Boost;
 
+use Nytris\Boost\FsCache\Realpath\RealpathCacheInterface;
+use Nytris\Boost\FsCache\Stat\StatCacheInterface;
 use Nytris\Boost\Library\LibraryInterface;
 
 /**
@@ -20,10 +22,26 @@ use Nytris\Boost\Library\LibraryInterface;
  *
  * Defines the public facade API for the library.
  *
+ * @phpstan-import-type MultipleStatCacheStorage from StatCacheInterface
+ * @phpstan-import-type RealpathCacheStorage from RealpathCacheInterface
  * @author Dan Phillimore <dan@ovms.co>
  */
 interface BoostInterface
 {
+    /**
+     * Fetches the in-memory realpath entry cache.
+     *
+     * @return RealpathCacheStorage
+     */
+    public function getInMemoryRealpathEntryCache(): array;
+
+    /**
+     * Fetches the in-memory stat entry cache.
+     *
+     * @return MultipleStatCacheStorage
+     */
+    public function getInMemoryStatEntryCache(): array;
+
     /**
      * Fetches the library installation for this Boost instance.
      */

--- a/src/BoostPackage.php
+++ b/src/BoostPackage.php
@@ -69,7 +69,7 @@ class BoostPackage implements BoostPackageInterface
         /**
          * Filter for which file paths to cache in the realpath, stat and contents caches.
          */
-        private readonly FileFilterInterface $pathFilter = new FileFilter('*')
+        private readonly FileFilterInterface $pathFilter = new FileFilter('**')
     ) {
     }
 

--- a/src/BoostPackage.php
+++ b/src/BoostPackage.php
@@ -50,7 +50,13 @@ class BoostPackage implements BoostPackageInterface
          * @var Closure(string): CacheItemPoolInterface
          */
         private readonly ?Closure $statCachePoolFactory = null,
+        /**
+         * @deprecated Unused - use the cache pool namespace.
+         */
         private readonly string $realpathCacheKey = FsCacheInterface::DEFAULT_REALPATH_CACHE_KEY,
+        /**
+         * @deprecated Unused - use the cache pool namespace.
+         */
         private readonly string $statCacheKey = FsCacheInterface::DEFAULT_STAT_CACHE_KEY,
         /**
          * Whether to hook built-in functions such as `clearstatcache(...)`.

--- a/src/BoostPackage.php
+++ b/src/BoostPackage.php
@@ -82,7 +82,23 @@ class BoostPackage implements BoostPackageInterface
          * In virtual-filesystem mode, the cache is write-allocate with no write-through
          * to the next stream handler in the chain (usually the original one, which persists to disk).
          */
-        private readonly bool $asVirtualFilesystem = false
+        private readonly bool $asVirtualFilesystem = false,
+        /**
+         * Read-only cache pool from which to preload the realpath cache.
+         *
+         * Set to null to disable preloading from a PSR cache.
+         *
+         * @var Closure(string): CacheItemPoolInterface
+         */
+        private readonly ?Closure $realpathPreloadCachePoolFactory = null,
+        /**
+         * Read-only cache pool from which to preload the stat cache.
+         *
+         * Set to null to disable preloading from a PSR cache.
+         *
+         * @var Closure(string): CacheItemPoolInterface
+         */
+        private readonly ?Closure $statPreloadCachePoolFactory = null
     ) {
         $this->hookBuiltinFunctionsFilter = match ($hookBuiltinFunctions) {
             true => new FileFilter('**'),
@@ -146,6 +162,16 @@ class BoostPackage implements BoostPackageInterface
     /**
      * @inheritDoc
      */
+    public function getRealpathPreloadCachePool(string $boostCachePath): ?CacheItemPoolInterface
+    {
+        return $this->realpathPreloadCachePoolFactory !== null ?
+            ($this->realpathPreloadCachePoolFactory)($boostCachePath) :
+            null;
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function getStatCacheKey(): string
     {
         return $this->statCacheKey;
@@ -158,6 +184,16 @@ class BoostPackage implements BoostPackageInterface
     {
         return $this->statCachePoolFactory !== null ?
             ($this->statCachePoolFactory)($boostCachePath) :
+            null;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getStatPreloadCachePool(string $boostCachePath): ?CacheItemPoolInterface
+    {
+        return $this->statPreloadCachePoolFactory !== null ?
+            ($this->statPreloadCachePoolFactory)($boostCachePath) :
             null;
     }
 

--- a/src/BoostPackageInterface.php
+++ b/src/BoostPackageInterface.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Nytris\Boost;
 
+use Asmblah\PhpCodeShift\Shifter\Filter\FileFilterInterface;
+use Nytris\Boost\FsCache\Contents\ContentsCacheInterface;
 use Nytris\Core\Package\PackageInterface;
 use Psr\Cache\CacheItemPoolInterface;
 
@@ -25,6 +27,16 @@ use Psr\Cache\CacheItemPoolInterface;
  */
 interface BoostPackageInterface extends PackageInterface
 {
+    /**
+     * Fetches the cache in which to store file contents, or null when disabled.
+     */
+    public function getContentsCache(string $boostCachePath): ?ContentsCacheInterface;
+
+    /**
+     * Fetches the filter for which file paths to cache.
+     */
+    public function getPathFilter(): FileFilterInterface;
+
     /**
      * Fetches the key to use for the realpath cache within the cache pool.
      */

--- a/src/BoostPackageInterface.php
+++ b/src/BoostPackageInterface.php
@@ -33,6 +33,12 @@ interface BoostPackageInterface extends PackageInterface
     public function getContentsCache(string $boostCachePath): ?ContentsCacheInterface;
 
     /**
+     * Fetches the filter for which files to hook built-in functions
+     * such as `clearstatcache(...)`. for, or null to disable.
+     */
+    public function getHookBuiltinFunctionsFilter(): ?FileFilterInterface;
+
+    /**
      * Fetches the filter for which file paths to cache.
      */
     public function getPathFilter(): FileFilterInterface;
@@ -64,12 +70,13 @@ interface BoostPackageInterface extends PackageInterface
     public function getStatCachePool(string $boostCachePath): ?CacheItemPoolInterface;
 
     /**
+     * In virtual-filesystem mode, the cache is write-allocate with no write-through
+     * to the next stream handler in the chain (usually the original one, which persists to disk).
+     */
+    public function isVirtualFilesystem(): bool;
+
+    /**
      * Fetches whether the non-existence of files should be cached in the realpath cache.
      */
     public function shouldCacheNonExistentFiles(): bool;
-
-    /**
-     * Fetches whether to hook built-in functions such as `clearstatcache(...)`.
-     */
-    public function shouldHookBuiltinFunctions(): bool;
 }

--- a/src/BoostPackageInterface.php
+++ b/src/BoostPackageInterface.php
@@ -45,6 +45,8 @@ interface BoostPackageInterface extends PackageInterface
 
     /**
      * Fetches the key to use for the realpath cache within the cache pool.
+     *
+     * @deprecated Unused - use the cache pool namespace.
      */
     public function getRealpathCacheKey(): string;
 
@@ -57,7 +59,16 @@ interface BoostPackageInterface extends PackageInterface
     public function getRealpathCachePool(string $boostCachePath): ?CacheItemPoolInterface;
 
     /**
+     * Fetches the read-only PSR cache pool to use for preloading the realpath cache.
+     *
+     * Set to null to disable preloading from a PSR cache.
+     */
+    public function getRealpathPreloadCachePool(string $boostCachePath): ?CacheItemPoolInterface;
+
+    /**
      * Fetches the key to use for the stat cache within the cache pool.
+     *
+     * @deprecated Unused - use the cache pool namespace.
      */
     public function getStatCacheKey(): string;
 
@@ -68,6 +79,13 @@ interface BoostPackageInterface extends PackageInterface
      * Cache will still be maintained for the life of the request/CLI process.
      */
     public function getStatCachePool(string $boostCachePath): ?CacheItemPoolInterface;
+
+    /**
+     * Fetches the read-only PSR cache pool to use for preloading the stat cache.
+     *
+     * Set to null to disable preloading from a PSR cache.
+     */
+    public function getStatPreloadCachePool(string $boostCachePath): ?CacheItemPoolInterface;
 
     /**
      * In virtual-filesystem mode, the cache is write-allocate with no write-through

--- a/src/Charge.php
+++ b/src/Charge.php
@@ -83,7 +83,9 @@ class Charge implements ChargeInterface
                 realpathCacheKey: $package->getRealpathCacheKey(),
                 statCacheKey: $package->getStatCacheKey(),
                 hookBuiltinFunctions: $package->shouldHookBuiltinFunctions(),
-                cacheNonExistentFiles: $package->shouldCacheNonExistentFiles()
+                cacheNonExistentFiles: $package->shouldCacheNonExistentFiles(),
+                contentsCache: $package->getContentsCache($packageContext->getPackageCachePath()),
+                pathFilter: $package->getPathFilter()
             )
         );
     }

--- a/src/Charge.php
+++ b/src/Charge.php
@@ -34,6 +34,22 @@ class Charge implements ChargeInterface
     /**
      * @inheritDoc
      */
+    public static function getInMemoryRealpathEntryCache(): array
+    {
+        return self::getLibrary()->getInMemoryRealpathEntryCache();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public static function getInMemoryStatEntryCache(): array
+    {
+        return self::getLibrary()->getInMemoryStatEntryCache();
+    }
+
+    /**
+     * @inheritDoc
+     */
     public static function getLibrary(): LibraryInterface
     {
         if (!self::$library) {
@@ -90,7 +106,9 @@ class Charge implements ChargeInterface
             cacheNonExistentFiles: $package->shouldCacheNonExistentFiles(),
             contentsCache: $package->getContentsCache($packageContext->getPackageCachePath()),
             pathFilter: $package->getPathFilter(),
-            asVirtualFilesystem: $package->isVirtualFilesystem()
+            asVirtualFilesystem: $package->isVirtualFilesystem(),
+            realpathPreloadCachePool: $package->getRealpathPreloadCachePool($packageContext->getPackageCachePath()),
+            statPreloadCachePool: $package->getStatPreloadCachePool($packageContext->getPackageCachePath())
         );
 
         $boost->install();

--- a/src/Charge.php
+++ b/src/Charge.php
@@ -76,18 +76,24 @@ class Charge implements ChargeInterface
             );
         }
 
-        self::$library = new Library(
-            new Boost(
-                realpathCachePool: $package->getRealpathCachePool($packageContext->getPackageCachePath()),
-                statCachePool: $package->getStatCachePool($packageContext->getPackageCachePath()),
-                realpathCacheKey: $package->getRealpathCacheKey(),
-                statCacheKey: $package->getStatCacheKey(),
-                hookBuiltinFunctions: $package->shouldHookBuiltinFunctions(),
-                cacheNonExistentFiles: $package->shouldCacheNonExistentFiles(),
-                contentsCache: $package->getContentsCache($packageContext->getPackageCachePath()),
-                pathFilter: $package->getPathFilter()
-            )
+        if (self::$library === null) {
+            self::$library = new Library();
+        }
+
+        $boost = new Boost(
+            library: self::$library,
+            realpathCachePool: $package->getRealpathCachePool($packageContext->getPackageCachePath()),
+            statCachePool: $package->getStatCachePool($packageContext->getPackageCachePath()),
+            realpathCacheKey: $package->getRealpathCacheKey(),
+            statCacheKey: $package->getStatCacheKey(),
+            hookBuiltinFunctions: $package->getHookBuiltinFunctionsFilter() ?? false,
+            cacheNonExistentFiles: $package->shouldCacheNonExistentFiles(),
+            contentsCache: $package->getContentsCache($packageContext->getPackageCachePath()),
+            pathFilter: $package->getPathFilter(),
+            asVirtualFilesystem: $package->isVirtualFilesystem()
         );
+
+        $boost->install();
     }
 
     /**

--- a/src/ChargeInterface.php
+++ b/src/ChargeInterface.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Nytris\Boost;
 
+use Nytris\Boost\FsCache\Realpath\RealpathCacheInterface;
+use Nytris\Boost\FsCache\Stat\StatCacheInterface;
 use Nytris\Boost\Library\LibraryInterface;
 use Nytris\Core\Package\PackageFacadeInterface;
 
@@ -21,10 +23,26 @@ use Nytris\Core\Package\PackageFacadeInterface;
  *
  * Defines the public facade API for the library as a Nytris package.
  *
+ * @phpstan-import-type MultipleStatCacheStorage from StatCacheInterface
+ * @phpstan-import-type RealpathCacheStorage from RealpathCacheInterface
  * @author Dan Phillimore <dan@ovms.co>
  */
 interface ChargeInterface extends PackageFacadeInterface
 {
+    /**
+     * Fetches the in-memory realpath entry cache across all registered Boost instances.
+     *
+     * @return RealpathCacheStorage
+     */
+    public static function getInMemoryRealpathEntryCache(): array;
+
+    /**
+     * Fetches the in-memory stat entry cache across all registered Boost instances.
+     *
+     * @return MultipleStatCacheStorage
+     */
+    public static function getInMemoryStatEntryCache(): array;
+
     /**
      * Fetches the current library installation.
      */

--- a/src/Environment/Environment.php
+++ b/src/Environment/Environment.php
@@ -22,11 +22,56 @@ namespace Nytris\Boost\Environment;
  */
 class Environment implements EnvironmentInterface
 {
+    private float $startTime;
+
+    public function __construct()
+    {
+        $this->startTime = isset($_SERVER['REQUEST_TIME']) ?
+            (float) $_SERVER['REQUEST_TIME'] :
+            $this->getTime();
+    }
+
     /**
      * @inheritDoc
      */
     public function getCwd(): string
     {
         return getcwd();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getGroupIdFromName(string $groupName): ?int
+    {
+        $groupInfo = posix_getgrnam($groupName);
+
+        return $groupInfo !== false ? $groupInfo['gid'] : null;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getStartTime(): float
+    {
+        return $this->startTime;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getTime(): float
+    {
+        return microtime(as_float: true);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getUserIdFromName(string $username): ?int
+    {
+        $userInfo = posix_getpwnam($username);
+
+        return $userInfo !== false ? $userInfo['uid'] : null;
     }
 }

--- a/src/Environment/Environment.php
+++ b/src/Environment/Environment.php
@@ -1,0 +1,32 @@
+<?php
+
+/*
+ * Nytris Boost
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\Environment;
+
+/**
+ * Class Environment.
+ *
+ * Abstraction over the execution environment.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class Environment implements EnvironmentInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function getCwd(): string
+    {
+        return getcwd();
+    }
+}

--- a/src/Environment/EnvironmentInterface.php
+++ b/src/Environment/EnvironmentInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * Nytris Boost
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\Environment;
+
+/**
+ * Interface EnvironmentInterface.
+ *
+ * Abstraction over the execution environment.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+interface EnvironmentInterface
+{
+    /**
+     * Fetches the current working directory.
+     */
+    public function getCwd(): string;
+}

--- a/src/Environment/EnvironmentInterface.php
+++ b/src/Environment/EnvironmentInterface.php
@@ -26,4 +26,24 @@ interface EnvironmentInterface
      * Fetches the current working directory.
      */
     public function getCwd(): string;
+
+    /**
+     * Fetches the group ID for the given POSIX group name.
+     */
+    public function getGroupIdFromName(string $groupName): ?int;
+
+    /**
+     * Fetches the Unix timestamp of program start with microseconds.
+     */
+    public function getStartTime(): float;
+
+    /**
+     * Fetches the current Unix timestamp with microseconds.
+     */
+    public function getTime(): float;
+
+    /**
+     * Fetches the user ID for the given POSIX username.
+     */
+    public function getUserIdFromName(string $username): ?int;
 }

--- a/src/FsCache/Canonicaliser.php
+++ b/src/FsCache/Canonicaliser.php
@@ -54,4 +54,12 @@ class Canonicaliser implements CanonicaliserInterface
 
         return $path;
     }
+
+    /**
+     * @inheritDoc
+     */
+    public function canonicaliseCacheKey(string $key): string
+    {
+        return hash('sha256', $key);
+    }
 }

--- a/src/FsCache/Canonicaliser.php
+++ b/src/FsCache/Canonicaliser.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Nytris\Boost\FsCache;
 
+use Nytris\Boost\Environment\EnvironmentInterface;
+
 /**
  * Class Canonicaliser.
  *
@@ -20,11 +22,18 @@ namespace Nytris\Boost\FsCache;
  */
 class Canonicaliser implements CanonicaliserInterface
 {
+    public function __construct(
+        private readonly EnvironmentInterface $environment
+    ) {
+    }
+
     /**
      * @inheritDoc
      */
-    public function canonicalise(string $path, string $cwd): string
+    public function canonicalise(string $path, ?string $cwd = null): string
     {
+        $cwd ??= $this->environment->getCwd();
+
         // Resolve same- or parent directory prefix segment.
         if (str_starts_with($path, './') || str_starts_with($path, '../')) {
             $path = $cwd . '/' . $path;

--- a/src/FsCache/CanonicaliserInterface.php
+++ b/src/FsCache/CanonicaliserInterface.php
@@ -27,4 +27,9 @@ interface CanonicaliserInterface
      * Uses the current working directory for the process if none is specified.
      */
     public function canonicalise(string $path, ?string $cwd = null): string;
+
+    /**
+     * Canonicalises the given cache key, sanitising it for PSR caching.
+     */
+    public function canonicaliseCacheKey(string $key): string;
 }

--- a/src/FsCache/CanonicaliserInterface.php
+++ b/src/FsCache/CanonicaliserInterface.php
@@ -22,7 +22,9 @@ interface CanonicaliserInterface
 {
     /**
      * Canonicalises the given path, resolving all "./", "../", "//" symbols etc.
+     *
      * Similar to the built-in realpath(...) function, except symlinks are not resolved.
+     * Uses the current working directory for the process if none is specified.
      */
-    public function canonicalise(string $path, string $cwd): string;
+    public function canonicalise(string $path, ?string $cwd = null): string;
 }

--- a/src/FsCache/Contents/CachedFile.php
+++ b/src/FsCache/Contents/CachedFile.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * Nytris Boost
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\FsCache\Contents;
+
+use LogicException;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+/**
+ * Class CachedFile.
+ *
+ * Represents a file in the contents cache.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class CachedFile implements CachedFileInterface
+{
+    private bool $isCached;
+
+    public function __construct(
+        private readonly CacheItemPoolInterface $cachePool,
+        private readonly CacheItemInterface $cachePoolItem
+    ) {
+        $this->isCached = $this->cachePoolItem->isHit();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getContents(): string
+    {
+        if (!$this->isCached) {
+            throw new LogicException('File contents are not yet cached');
+        }
+
+        return $this->cachePoolItem->get();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isCached(): bool
+    {
+        return $this->isCached;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setContents(string $contents): void
+    {
+        $this->cachePoolItem->set($contents);
+        $this->cachePool->saveDeferred($this->cachePoolItem);
+
+        $this->isCached = true;
+    }
+}

--- a/src/FsCache/Contents/CachedFileInterface.php
+++ b/src/FsCache/Contents/CachedFileInterface.php
@@ -1,0 +1,39 @@
+<?php
+
+/*
+ * Nytris Boost
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\FsCache\Contents;
+
+/**
+ * Interface CachedFileInterface.
+ *
+ * Represents a file in the contents cache.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+interface CachedFileInterface
+{
+    /**
+     * Fetches the cached contents of the file.
+     */
+    public function getContents(): string;
+
+    /**
+     * Determines whether the file has yet been cached.
+     */
+    public function isCached(): bool;
+
+    /**
+     * Updates the cached contents of the file.
+     */
+    public function setContents(string $contents): void;
+}

--- a/src/FsCache/Contents/ContentsCacheInterface.php
+++ b/src/FsCache/Contents/ContentsCacheInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * Nytris Boost
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\FsCache\Contents;
+
+/**
+ * Interface ContentsCacheInterface.
+ *
+ * Caches file contents vs. the realpath and stat caches.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+interface ContentsCacheInterface
+{
+    public const DEFAULT_CACHE_KEY_PREFIX = '__nytris_boost_contents_cache_';
+
+    /**
+     * Hashes the given cache key to support arbitrary-length keys.
+     *
+     * Plain and include streams are cached separately, because include streams' contents
+     * may differ from the originals due to code shifting.
+     */
+    public function buildCacheKey(string $prefix, string $key, bool $isInclude): string;
+
+    /**
+     * Fetches the cache item for the given path and plain file or include mode.
+     */
+    public function getItemForPath(string $path, bool $isInclude): CachedFileInterface;
+
+    /**
+     * Invalidates any content cache entries for the given path.
+     */
+    public function invalidatePath(string $path): void;
+}

--- a/src/FsCache/Contents/MultiplePoolContentsCache.php
+++ b/src/FsCache/Contents/MultiplePoolContentsCache.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * Nytris Boost
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\FsCache\Contents;
+
+use Psr\Cache\CacheItemPoolInterface;
+
+/**
+ * Class MultiplePoolContentsCache.
+ *
+ * A file contents cache backed by multiple PSR-6 cache pools.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class MultiplePoolContentsCache implements ContentsCacheInterface
+{
+    /**
+     * @param PartitionInterface[] $partitions Prioritised list of partitions responsible for specific files.
+     * @param CacheItemPoolInterface $fallbackPsrCachePool
+     * @param string $fallbackCacheKeyPrefix
+     */
+    public function __construct(
+        private readonly array $partitions,
+        private readonly CacheItemPoolInterface $fallbackPsrCachePool,
+        /**
+         * The prefix to use for the keys of the cache within the fallback cache pool.
+         */
+        private readonly string $fallbackCacheKeyPrefix = self::DEFAULT_CACHE_KEY_PREFIX
+    ) {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function buildCacheKey(string $prefix, string $key, bool $isInclude): string
+    {
+        return $prefix . ($isInclude ? '_include_' : '_plain_') . hash('sha256', $key);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getItemForPath(string $path, bool $isInclude): CachedFileInterface
+    {
+        foreach ($this->partitions as $partition) {
+            $item = $partition->getItemForPath($path, $isInclude, $this);
+
+            if ($item !== null) {
+                return $item; // This partition is responsible for this path, so we can early-out.
+            }
+        }
+
+        // No partition claimed this path, so use the fallback pool.
+        $cacheKey = $this->buildCacheKey($this->fallbackCacheKeyPrefix, $path, $isInclude);
+
+        return new CachedFile($this->fallbackPsrCachePool, $this->fallbackPsrCachePool->getItem($cacheKey));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function invalidatePath(string $path): void
+    {
+        foreach ($this->partitions as $partition) {
+            if ($partition->invalidatePath($path, $this) === true) {
+                return; // This partition is responsible for this path, so we can early-out.
+            }
+        }
+
+        // No partition claimed this path, invalidate any cache entries
+        // for both plain or include (shifted) variants in the fallback pool.
+        $this->fallbackPsrCachePool->deleteItem($this->buildCacheKey($this->fallbackCacheKeyPrefix, $path, true));
+        $this->fallbackPsrCachePool->deleteItem($this->buildCacheKey($this->fallbackCacheKeyPrefix, $path, false));
+    }
+}

--- a/src/FsCache/Contents/PartitionInterface.php
+++ b/src/FsCache/Contents/PartitionInterface.php
@@ -1,0 +1,42 @@
+<?php
+
+/*
+ * Nytris Boost
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\FsCache\Contents;
+
+/**
+ * Interface PartitionInterface.
+ *
+ * Represents a separate cache area to store contents for certain paths.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+interface PartitionInterface
+{
+    /**
+     * Fetches the cache item for the given path and plain file or include mode.
+     *
+     * Returns null if this partition is not responsible for the given path.
+     */
+    public function getItemForPath(
+        string $path,
+        bool $isInclude,
+        ContentsCacheInterface $contentsCache
+    ): ?CachedFileInterface;
+
+    /**
+     * Invalidates any content cache entries in this partition for the given path.
+     *
+     * Returns true if the path is within this partition, false otherwise.
+     */
+    public function invalidatePath(string $path, ContentsCacheInterface $contentsCache): bool;
+}

--- a/src/FsCache/Contents/PoolBackedPartition.php
+++ b/src/FsCache/Contents/PoolBackedPartition.php
@@ -1,0 +1,75 @@
+<?php
+
+/*
+ * Nytris Boost
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\FsCache\Contents;
+
+use Asmblah\PhpCodeShift\Shifter\Filter\FileFilterInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+/**
+ * Class PoolBackedPartition.
+ *
+ * Stores contents for specific files defined by a filter.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class PoolBackedPartition implements PartitionInterface
+{
+    public function __construct(
+        private readonly CacheItemPoolInterface $psrCachePool,
+        /**
+         * Specifies which paths this partition is responsible for.
+         */
+        private readonly FileFilterInterface $pathFilter,
+        /**
+         * The prefix to use for the keys of the cache within the cache pool.
+         */
+        private readonly string $cacheKeyPrefix = ContentsCacheInterface::DEFAULT_CACHE_KEY_PREFIX
+    ) {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getItemForPath(
+        string $path,
+        bool $isInclude,
+        ContentsCacheInterface $contentsCache
+    ): ?CachedFileInterface {
+        if (!$this->pathFilter->fileMatches($path)) {
+            // This partition is not responsible for this path.
+            return null;
+        }
+
+        $cacheKey = $contentsCache->buildCacheKey($this->cacheKeyPrefix, $path, $isInclude);
+
+        return new CachedFile($this->psrCachePool, $this->psrCachePool->getItem($cacheKey));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function invalidatePath(string $path, ContentsCacheInterface $contentsCache): bool
+    {
+        if (!$this->pathFilter->fileMatches($path)) {
+            // This partition is not responsible for this path.
+            return false;
+        }
+
+        // Invalidate any cache entries for both plain or include (shifted) variants.
+        $this->psrCachePool->deleteItem($contentsCache->buildCacheKey($this->cacheKeyPrefix, $path, true));
+        $this->psrCachePool->deleteItem($contentsCache->buildCacheKey($this->cacheKeyPrefix, $path, false));
+
+        return true;
+    }
+}

--- a/src/FsCache/Contents/SinglePoolContentsCache.php
+++ b/src/FsCache/Contents/SinglePoolContentsCache.php
@@ -1,0 +1,63 @@
+<?php
+
+/*
+ * Nytris Boost
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\FsCache\Contents;
+
+use Psr\Cache\CacheItemPoolInterface;
+
+/**
+ * Class SinglePoolContentsCache.
+ *
+ * A file contents cache backed by a single PSR-6 cache pool.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class SinglePoolContentsCache implements ContentsCacheInterface
+{
+    public function __construct(
+        private readonly CacheItemPoolInterface $psrCachePool,
+        /**
+         * The prefix to use for the keys of the cache within the cache pool.
+         */
+        private readonly string $cacheKeyPrefix = self::DEFAULT_CACHE_KEY_PREFIX
+    ) {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function buildCacheKey(string $prefix, string $key, bool $isInclude): string
+    {
+        return $prefix . ($isInclude ? '_include_' : '_plain_') . hash('sha256', $key);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getItemForPath(string $path, bool $isInclude): CachedFileInterface
+    {
+        $cacheKey = $this->buildCacheKey($this->cacheKeyPrefix, $path, $isInclude);
+
+        return new CachedFile($this->psrCachePool, $this->psrCachePool->getItem($cacheKey));
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function invalidatePath(string $path): void
+    {
+        // Invalidate any cache entries for both plain or include (shifted) variants.
+        $this->psrCachePool->deleteItem($this->buildCacheKey($this->cacheKeyPrefix, $path, true));
+        $this->psrCachePool->deleteItem($this->buildCacheKey($this->cacheKeyPrefix, $path, false));
+    }
+}

--- a/src/FsCache/FsCache.php
+++ b/src/FsCache/FsCache.php
@@ -36,7 +36,9 @@ class FsCache implements FsCacheInterface
 
     public function __construct(
         private readonly FsCacheFactoryInterface $fsCacheFactory,
+        private readonly ?CacheItemPoolInterface $realpathPreloadCachePool,
         private readonly CacheItemPoolInterface $realpathCachePool,
+        private readonly ?CacheItemPoolInterface $statPreloadCachePool,
         private readonly CacheItemPoolInterface $statCachePool,
         private readonly ?ContentsCacheInterface $contentsCache,
         private readonly string $realpathCacheKey,
@@ -53,13 +55,31 @@ class FsCache implements FsCacheInterface
     /**
      * @inheritDoc
      */
+    public function getInMemoryRealpathEntryCache(): array
+    {
+        return $this->fsCachingStreamHandler->getInMemoryRealpathEntryCache();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getInMemoryStatEntryCache(): array
+    {
+        return $this->fsCachingStreamHandler->getInMemoryStatEntryCache();
+    }
+
+    /**
+     * @inheritDoc
+     */
     public function install(): void
     {
         $this->originalStreamHandler = StreamWrapperManager::getStreamHandler();
 
         $this->fsCachingStreamHandler = $this->fsCacheFactory->createStreamHandler(
             $this->originalStreamHandler,
+            $this->realpathPreloadCachePool,
             $this->realpathCachePool,
+            $this->statPreloadCachePool,
             $this->statCachePool,
             $this->contentsCache,
             $this->realpathCacheKey,

--- a/src/FsCache/FsCache.php
+++ b/src/FsCache/FsCache.php
@@ -36,8 +36,8 @@ class FsCache implements FsCacheInterface
 
     public function __construct(
         private readonly FsCacheFactoryInterface $fsCacheFactory,
-        private readonly ?CacheItemPoolInterface $realpathCachePool,
-        private readonly ?CacheItemPoolInterface $statCachePool,
+        private readonly CacheItemPoolInterface $realpathCachePool,
+        private readonly CacheItemPoolInterface $statCachePool,
         private readonly ?ContentsCacheInterface $contentsCache,
         private readonly string $realpathCacheKey,
         private readonly string $statCacheKey,
@@ -48,13 +48,6 @@ class FsCache implements FsCacheInterface
         private readonly FileFilterInterface $pathFilter,
         private readonly bool $asVirtualFilesystem
     ) {
-        /**
-         * To reduce I/O, defer PSR cache persistence (if enabled)
-         * until the end of the request or CLI process.
-         */
-        register_shutdown_function(function () {
-            $this->persistCaches();
-        });
     }
 
     /**

--- a/src/FsCache/FsCacheFactory.php
+++ b/src/FsCache/FsCacheFactory.php
@@ -44,23 +44,21 @@ class FsCacheFactory implements FsCacheFactoryInterface
      */
     public function createStreamHandler(
         StreamHandlerInterface $originalStreamHandler,
-        ?CacheItemPoolInterface $realpathCachePool,
-        ?CacheItemPoolInterface $statCachePool,
+        CacheItemPoolInterface $realpathCachePool,
+        CacheItemPoolInterface $statCachePool,
         ?ContentsCacheInterface $contentsCache,
         string $realpathCacheKey,
         string $statCacheKey,
-        /**
-         * Whether the non-existence of files should be cached in the realpath cache.
-         */
         bool $cacheNonExistentFiles,
         FileFilterInterface $pathFilter,
         bool $asVirtualFilesystem
     ): FsCachingStreamHandlerInterface {
+        // TODO: Remove now-unused $realpathCacheKey & $statCacheKey on next breaking 0.x bump.
+
         $realpathCache = new RealpathCache(
             $originalStreamHandler,
             $this->canonicaliser,
             $realpathCachePool,
-            $realpathCacheKey,
             $cacheNonExistentFiles,
             $asVirtualFilesystem
         );
@@ -70,7 +68,6 @@ class FsCacheFactory implements FsCacheFactoryInterface
             $this->canonicaliser,
             $realpathCache,
             $statCachePool,
-            $statCacheKey,
             $asVirtualFilesystem
         );
         $streamOpener = new StreamOpener(

--- a/src/FsCache/FsCacheFactory.php
+++ b/src/FsCache/FsCacheFactory.php
@@ -18,6 +18,7 @@ use Asmblah\PhpCodeShift\Shifter\Stream\Handler\StreamHandlerInterface;
 use Nytris\Boost\FsCache\Contents\ContentsCacheInterface;
 use Nytris\Boost\FsCache\Stream\Handler\FsCachingStreamHandler;
 use Nytris\Boost\FsCache\Stream\Handler\FsCachingStreamHandlerInterface;
+use Nytris\Boost\FsCache\Stream\Opener\StreamOpener;
 use Psr\Cache\CacheItemPoolInterface;
 
 /**
@@ -52,6 +53,11 @@ class FsCacheFactory implements FsCacheFactoryInterface
     ): FsCachingStreamHandlerInterface {
         return new FsCachingStreamHandler(
             $originalStreamHandler,
+            new StreamOpener(
+                $originalStreamHandler,
+                $this->canonicaliser,
+                $contentsCache
+            ),
             $this->canonicaliser,
             $realpathCachePool,
             $statCachePool,

--- a/src/FsCache/FsCacheFactory.php
+++ b/src/FsCache/FsCacheFactory.php
@@ -44,7 +44,9 @@ class FsCacheFactory implements FsCacheFactoryInterface
      */
     public function createStreamHandler(
         StreamHandlerInterface $originalStreamHandler,
+        ?CacheItemPoolInterface $realpathPreloadCachePool,
         CacheItemPoolInterface $realpathCachePool,
+        ?CacheItemPoolInterface $statPreloadCachePool,
         CacheItemPoolInterface $statCachePool,
         ?ContentsCacheInterface $contentsCache,
         string $realpathCacheKey,
@@ -58,6 +60,7 @@ class FsCacheFactory implements FsCacheFactoryInterface
         $realpathCache = new RealpathCache(
             $originalStreamHandler,
             $this->canonicaliser,
+            $realpathPreloadCachePool,
             $realpathCachePool,
             $cacheNonExistentFiles,
             $asVirtualFilesystem
@@ -67,6 +70,7 @@ class FsCacheFactory implements FsCacheFactoryInterface
             $this->environment,
             $this->canonicaliser,
             $realpathCache,
+            $statPreloadCachePool,
             $statCachePool,
             $asVirtualFilesystem
         );

--- a/src/FsCache/FsCacheFactory.php
+++ b/src/FsCache/FsCacheFactory.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace Nytris\Boost\FsCache;
 
+use Asmblah\PhpCodeShift\Shifter\Filter\FileFilterInterface;
 use Asmblah\PhpCodeShift\Shifter\Stream\Handler\StreamHandlerInterface;
+use Nytris\Boost\FsCache\Contents\ContentsCacheInterface;
 use Nytris\Boost\FsCache\Stream\Handler\FsCachingStreamHandler;
 use Nytris\Boost\FsCache\Stream\Handler\FsCachingStreamHandlerInterface;
 use Psr\Cache\CacheItemPoolInterface;
@@ -39,21 +41,25 @@ class FsCacheFactory implements FsCacheFactoryInterface
         StreamHandlerInterface $originalStreamHandler,
         ?CacheItemPoolInterface $realpathCachePool,
         ?CacheItemPoolInterface $statCachePool,
-        string $realpathCacheKey = FsCacheInterface::DEFAULT_REALPATH_CACHE_KEY,
-        string $statCacheKey = FsCacheInterface::DEFAULT_STAT_CACHE_KEY,
+        ?ContentsCacheInterface $contentsCache,
+        string $realpathCacheKey,
+        string $statCacheKey,
         /**
          * Whether the non-existence of files should be cached in the realpath cache.
          */
-        bool $cacheNonExistentFiles = true
+        bool $cacheNonExistentFiles,
+        FileFilterInterface $pathFilter
     ): FsCachingStreamHandlerInterface {
         return new FsCachingStreamHandler(
             $originalStreamHandler,
             $this->canonicaliser,
             $realpathCachePool,
             $statCachePool,
+            $contentsCache,
             $realpathCacheKey,
             $statCacheKey,
-            $cacheNonExistentFiles
+            $cacheNonExistentFiles,
+            $pathFilter
         );
     }
 }

--- a/src/FsCache/FsCacheFactoryInterface.php
+++ b/src/FsCache/FsCacheFactoryInterface.php
@@ -33,11 +33,14 @@ interface FsCacheFactoryInterface
      */
     public function createStreamHandler(
         StreamHandlerInterface $originalStreamHandler,
-        ?CacheItemPoolInterface $realpathCachePool,
-        ?CacheItemPoolInterface $statCachePool,
+        CacheItemPoolInterface $realpathCachePool,
+        CacheItemPoolInterface $statCachePool,
         ?ContentsCacheInterface $contentsCache,
         string $realpathCacheKey,
         string $statCacheKey,
+        /**
+         * Whether the non-existence of files should be cached in the realpath cache.
+         */
         bool $cacheNonExistentFiles,
         FileFilterInterface $pathFilter,
         bool $asVirtualFilesystem

--- a/src/FsCache/FsCacheFactoryInterface.php
+++ b/src/FsCache/FsCacheFactoryInterface.php
@@ -33,7 +33,9 @@ interface FsCacheFactoryInterface
      */
     public function createStreamHandler(
         StreamHandlerInterface $originalStreamHandler,
+        ?CacheItemPoolInterface $realpathPreloadCachePool,
         CacheItemPoolInterface $realpathCachePool,
+        ?CacheItemPoolInterface $statPreloadCachePool,
         CacheItemPoolInterface $statCachePool,
         ?ContentsCacheInterface $contentsCache,
         string $realpathCacheKey,

--- a/src/FsCache/FsCacheFactoryInterface.php
+++ b/src/FsCache/FsCacheFactoryInterface.php
@@ -39,6 +39,7 @@ interface FsCacheFactoryInterface
         string $realpathCacheKey,
         string $statCacheKey,
         bool $cacheNonExistentFiles,
-        FileFilterInterface $pathFilter
+        FileFilterInterface $pathFilter,
+        bool $asVirtualFilesystem
     ): FsCachingStreamHandlerInterface;
 }

--- a/src/FsCache/FsCacheFactoryInterface.php
+++ b/src/FsCache/FsCacheFactoryInterface.php
@@ -13,7 +13,9 @@ declare(strict_types=1);
 
 namespace Nytris\Boost\FsCache;
 
+use Asmblah\PhpCodeShift\Shifter\Filter\FileFilterInterface;
 use Asmblah\PhpCodeShift\Shifter\Stream\Handler\StreamHandlerInterface;
+use Nytris\Boost\FsCache\Contents\ContentsCacheInterface;
 use Nytris\Boost\FsCache\Stream\Handler\FsCachingStreamHandlerInterface;
 use Psr\Cache\CacheItemPoolInterface;
 
@@ -33,8 +35,10 @@ interface FsCacheFactoryInterface
         StreamHandlerInterface $originalStreamHandler,
         ?CacheItemPoolInterface $realpathCachePool,
         ?CacheItemPoolInterface $statCachePool,
-        string $realpathCacheKey = FsCacheInterface::DEFAULT_REALPATH_CACHE_KEY,
-        string $statCacheKey = FsCacheInterface::DEFAULT_STAT_CACHE_KEY,
-        bool $cacheNonExistentFiles = true
+        ?ContentsCacheInterface $contentsCache,
+        string $realpathCacheKey,
+        string $statCacheKey,
+        bool $cacheNonExistentFiles,
+        FileFilterInterface $pathFilter
     ): FsCachingStreamHandlerInterface;
 }

--- a/src/FsCache/FsCacheInterface.php
+++ b/src/FsCache/FsCacheInterface.php
@@ -13,17 +13,36 @@ declare(strict_types=1);
 
 namespace Nytris\Boost\FsCache;
 
+use Nytris\Boost\FsCache\Realpath\RealpathCacheInterface;
+use Nytris\Boost\FsCache\Stat\StatCacheInterface;
+
 /**
  * Interface FsCacheInterface.
  *
  * Emulates the PHP realpath and stat caches in userland, even when open_basedir is enabled.
  *
+ * @phpstan-import-type MultipleStatCacheStorage from StatCacheInterface
+ * @phpstan-import-type RealpathCacheStorage from RealpathCacheInterface
  * @author Dan Phillimore <dan@ovms.co>
  */
 interface FsCacheInterface
 {
     public const DEFAULT_REALPATH_CACHE_KEY = '__nytris_boost_realpath_cache';
     public const DEFAULT_STAT_CACHE_KEY = '__nytris_boost_stat_cache';
+
+    /**
+     * Fetches the in-memory realpath entry cache.
+     *
+     * @return RealpathCacheStorage
+     */
+    public function getInMemoryRealpathEntryCache(): array;
+
+    /**
+     * Fetches the in-memory stat entry cache.
+     *
+     * @return MultipleStatCacheStorage
+     */
+    public function getInMemoryStatEntryCache(): array;
 
     /**
      * Installs the filesystem cache.

--- a/src/FsCache/FsCacheInterface.php
+++ b/src/FsCache/FsCacheInterface.php
@@ -31,6 +31,13 @@ interface FsCacheInterface
     public function install(): void;
 
     /**
+     * Clears the realpath and stat caches.
+     *
+     * Note that this does not affect the contents cache.
+     */
+    public function invalidateCaches(): void;
+
+    /**
      * Uninstalls the filesystem cache.
      */
     public function uninstall(): void;

--- a/src/FsCache/Realpath/RealpathCache.php
+++ b/src/FsCache/Realpath/RealpathCache.php
@@ -1,0 +1,318 @@
+<?php
+
+/*
+ * Nytris Boost
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\FsCache\Realpath;
+
+use Asmblah\PhpCodeShift\Shifter\Stream\Handler\StreamHandlerInterface;
+use Nytris\Boost\FsCache\CanonicaliserInterface;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+/**
+ * Class RealpathCache.
+ *
+ * Caches realpaths, optionally also to a PSR cache implementation, to improve performance.
+ *
+ * @phpstan-import-type RealpathCacheStorage from RealpathCacheInterface
+ * @phpstan-import-type RealpathCacheEntry from RealpathCacheInterface
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class RealpathCache implements RealpathCacheInterface
+{
+    /**
+     * @var RealpathCacheStorage
+     */
+    private array $realpathCache = [];
+    private bool $realpathCacheIsDirty = false;
+    private ?CacheItemInterface $realpathCachePoolItem = null;
+
+    public function __construct(
+        private readonly StreamHandlerInterface $wrappedStreamHandler,
+        private readonly CanonicaliserInterface $canonicaliser,
+        private readonly ?CacheItemPoolInterface $realpathCachePool,
+        string $realpathCacheKey,
+        /**
+         * Whether the non-existence of files should be cached in the realpath cache.
+         */
+        private readonly bool $cacheNonExistentFiles,
+        private readonly bool $asVirtualFilesystem
+    ) {
+        // Load the realpath cache from the PSR cache if enabled.
+        if ($this->realpathCachePool !== null) {
+            $this->realpathCachePoolItem = $this->realpathCachePool->getItem($realpathCacheKey);
+
+            if ($this->realpathCachePoolItem->isHit()) {
+                $this->realpathCache = $this->realpathCachePoolItem->get();
+            }
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function cacheRealpath(string $canonicalPath, string $realpath): void
+    {
+        $this->realpathCache[$realpath] = [
+            'realpath' => $realpath,
+        ];
+
+        if ($canonicalPath !== $realpath) {
+            // Canonical path is not the same as the realpath, e.g. path is a symlink.
+            // Add pointer entry from canonical targeting the final symlink one.
+            $this->realpathCache[$canonicalPath] = [
+                'symlink' => $realpath,
+            ];
+        }
+
+        $this->realpathCacheIsDirty = true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getCachedEventualPath(
+        string $path,
+        bool $followSymlinks = true,
+        bool &$accessible = true
+    ): string {
+        $entry = $this->realpathCache[$path] ?? null;
+
+        if ($entry === null) {
+            return $path;
+        }
+
+        $canonicalPath = $entry['canonical'] ?? null;
+
+        if ($canonicalPath !== null) {
+            $entry = $this->realpathCache[$canonicalPath] ?? null;
+
+            if ($entry === null) {
+                return $canonicalPath;
+            }
+        }
+
+        if ($followSymlinks) {
+            $symlinkPath = $entry['symlink'] ?? null;
+
+            if ($symlinkPath !== null) {
+                $entry = $this->realpathCache[$symlinkPath] ?? null;
+
+                if ($entry === null) {
+                    return $symlinkPath;
+                }
+            }
+        } else {
+            $symlinkPath = null;
+        }
+
+        if (($entry['exists'] ?? true) === false) {
+            $accessible = false;
+        }
+
+        return $entry['realpath'] ?? $canonicalPath ?? $symlinkPath ?? $path;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getEventualPath(
+        string $path,
+        bool $followSymlinks = true,
+        bool &$accessible = true
+    ): string {
+        return $this->getRealpath(
+            $path,
+            getEventual: true,
+            followSymlinks: $followSymlinks,
+            accessible: $accessible
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getRealpath(
+        string $path,
+        bool $getEventual = false,
+        bool $followSymlinks = true,
+        bool &$accessible = true
+    ): ?string {
+        $entry = $this->getRealpathCacheEntry($path, followSymlinks: $followSymlinks);
+
+        if ($entry !== null) {
+            $exists = $entry['exists'] ?? true;
+
+            if (!$exists) {
+                // File has been cached as non-existent.
+                $accessible = false;
+
+                return $getEventual ? $path : null;
+            }
+
+            $realpath = $entry['realpath'] ?? $entry['symlink'];
+        } else {
+            $realpath = null;
+        }
+
+        if ($realpath !== null) {
+            return $realpath;
+        }
+
+        $canonicalPath = $this->canonicaliser->canonicalise($path);
+
+        if ($path !== $canonicalPath) {
+            // Path is not canonical, add pointer entry targeting the canonical one.
+            $this->realpathCache[$path] = [
+                'canonical' => $canonicalPath,
+            ];
+
+            $this->realpathCacheIsDirty = true;
+        }
+
+        if ($this->asVirtualFilesystem || !$followSymlinks) {
+            // We cannot hit the backing store in order to resolve a true realpath -
+            // just use the canonical one.
+            $realpath = $canonicalPath;
+        } else {
+            $realpath = realpath($path);
+        }
+
+        if ($realpath === false) {
+            if ($this->wrappedStreamHandler->unwrapped(fn () => is_link($path))) {
+                // File is a symlink to an inaccessible target file.
+                $symlinkTarget = readlink($path);
+
+                if ($symlinkTarget !== false) {
+                    $canonicalSymlinkTarget = $this->canonicaliser->canonicalise($symlinkTarget);
+
+                    $this->realpathCache[$canonicalPath] = [
+                        'symlink' => $canonicalSymlinkTarget,
+                    ];
+
+                    if ($this->cacheNonExistentFiles) {
+                        $this->realpathCache[$canonicalSymlinkTarget] = [
+                            'exists' => false,
+                        ];
+                    }
+
+                    $this->realpathCacheIsDirty = true;
+
+                    // File does not exist or is inaccessible.
+                    return $getEventual ? $canonicalSymlinkTarget : null;
+                }
+            }
+
+            if ($this->cacheNonExistentFiles) {
+                // Add canonical entry.
+                $this->realpathCache[$canonicalPath] = [
+                    'exists' => false,
+                ];
+            }
+
+            $this->realpathCacheIsDirty = true;
+
+            // File does not exist or is inaccessible.
+            $accessible = false;
+
+            return $getEventual ? $canonicalPath : null;
+        }
+
+        $this->cacheRealpath($canonicalPath, $realpath);
+
+        return $realpath;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getRealpathCacheEntry(string $path, bool $followSymlinks): ?array
+    {
+        $entry = $this->realpathCache[$path] ?? null;
+
+        if ($entry === null) {
+            // TODO: Clear pointer entry from cache?
+
+            return null; // Not in cache; early-out.
+        }
+
+        $canonicalPath = $entry['canonical'] ?? null;
+
+        if ($canonicalPath !== null) {
+            $entry = $this->realpathCache[$canonicalPath] ?? null;
+
+            if ($entry === null) {
+                // TODO: Clear pointer entry from cache?
+
+                return null; // Not in cache; early-out.
+            }
+        }
+
+        if ($followSymlinks) {
+            $symlinkPath = $entry['symlink'] ?? null;
+
+            if ($symlinkPath !== null) {
+                $entry = $this->realpathCache[$symlinkPath] ?? null;
+
+                if ($entry === null) {
+                    // TODO: Clear pointer entry from cache?
+
+                    return null; // Not in cache; early-out.
+                }
+            }
+        }
+
+        return $entry;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function invalidate(): void
+    {
+        $this->realpathCache = [];
+
+        $this->realpathCacheIsDirty = true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function invalidatePath(string $path): void
+    {
+        // Resolve this first, as it may need the canonical path that is cleared below.
+        $eventualPath = $this->getCachedEventualPath($path);
+
+        // Clear the canonical path entries (which may be pointed to by some symbolic path entries -
+        // this action will effectively invalidate those too).
+        $canonicalPath = $this->canonicaliser->canonicalise($path);
+        unset($this->realpathCache[$canonicalPath]);
+
+        // Clear the eventual path entries if not cleared above.
+        unset($this->realpathCache[$eventualPath]);
+
+        $this->realpathCacheIsDirty = true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function persistRealpathCache(): void
+    {
+        if ($this->realpathCachePoolItem === null || $this->realpathCacheIsDirty === false) {
+            return; // Persistence is disabled or nothing changed; nothing to do.
+        }
+
+        $this->realpathCachePoolItem->set($this->realpathCache);
+        $this->realpathCachePool->saveDeferred($this->realpathCachePoolItem);
+    }
+}

--- a/src/FsCache/Realpath/RealpathCache.php
+++ b/src/FsCache/Realpath/RealpathCache.php
@@ -83,7 +83,7 @@ class RealpathCache implements RealpathCacheInterface
      * @param string $realpath
      * @return array<mixed>|null
      */
-    private function getBackingCacheEntry(string $realpath): ?array
+    public function getBackingCacheEntry(string $realpath): ?array
     {
         if (array_key_exists($realpath, $this->realpathEntryCache)) {
             return $this->realpathEntryCache[$realpath];
@@ -326,7 +326,7 @@ class RealpathCache implements RealpathCacheInterface
      * @param string $realpath
      * @param array<mixed> $entry
      */
-    private function setBackingCacheEntry(string $realpath, array $entry): void
+    public function setBackingCacheEntry(string $realpath, array $entry): void
     {
         $realpathCacheItem = $this->realpathCachePool->getItem(
             $this->canonicaliser->canonicaliseCacheKey($realpath)
@@ -334,5 +334,7 @@ class RealpathCache implements RealpathCacheInterface
 
         $realpathCacheItem->set($entry);
         $this->realpathCachePool->saveDeferred($realpathCacheItem);
+
+        $this->realpathEntryCache[$realpath] = $entry;
     }
 }

--- a/src/FsCache/Realpath/RealpathCacheInterface.php
+++ b/src/FsCache/Realpath/RealpathCacheInterface.php
@@ -18,7 +18,6 @@ namespace Nytris\Boost\FsCache\Realpath;
  *
  * Caches realpaths, optionally also to a PSR cache implementation, to improve performance.
  *
- * @phpstan-type RealpathCacheStorage array<string, RealpathCacheEntry>
  * @phpstan-type RealpathCacheEntry array{canonical?: string, exists?: bool, realpath?: string, symlink?: string}
  * @author Dan Phillimore <dan@ovms.co>
  */

--- a/src/FsCache/Realpath/RealpathCacheInterface.php
+++ b/src/FsCache/Realpath/RealpathCacheInterface.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * Nytris Boost
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\FsCache\Realpath;
+
+/**
+ * Interface RealpathCacheInterface.
+ *
+ * Caches realpaths, optionally also to a PSR cache implementation, to improve performance.
+ *
+ * @phpstan-type RealpathCacheStorage array<string, RealpathCacheEntry>
+ * @phpstan-type RealpathCacheEntry array{canonical?: string, exists?: bool, realpath?: string, symlink?: string}
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+interface RealpathCacheInterface
+{
+    /**
+     * Adds the given path (and all segments of the realpath) to the realpath cache.
+     */
+    public function cacheRealpath(string $canonicalPath, string $realpath): void;
+
+    /**
+     * Fetches the realpath for the given path if cached, even if its existence is not known.
+     */
+    public function getCachedEventualPath(
+        string $path,
+        bool $followSymlinks = true,
+        bool &$accessible = true
+    ): string;
+
+    /**
+     * Fetches the realpath for the given path, even if it does not exist.
+     */
+    public function getEventualPath(
+        string $path,
+        bool $followSymlinks = true,
+        bool &$accessible = true
+    ): string;
+
+    /**
+     * Fetches the realpath for the given path if cached,
+     * otherwise resolves and caches it.
+     */
+    public function getRealpath(
+        string $path,
+        bool $getEventual = false,
+        bool $followSymlinks = true,
+        bool &$accessible = true
+    ): ?string;
+
+    /**
+     * Fetches the realpath cache entry for the given path if cached,
+     * or null otherwise.
+     *
+     * @param string $path
+     * @param bool $followSymlinks
+     * @return RealpathCacheEntry|null
+     */
+    public function getRealpathCacheEntry(string $path, bool $followSymlinks): ?array;
+
+    /**
+     * Clears the realpath cache.
+     */
+    public function invalidate(): void;
+
+    /**
+     * Clears the realpath cache for the given path.
+     */
+    public function invalidatePath(string $path): void;
+
+    /**
+     * Persists the current realpath cache via configured PSR cache.
+     */
+    public function persistRealpathCache(): void;
+}

--- a/src/FsCache/Realpath/RealpathCacheInterface.php
+++ b/src/FsCache/Realpath/RealpathCacheInterface.php
@@ -18,15 +18,31 @@ namespace Nytris\Boost\FsCache\Realpath;
  *
  * Caches realpaths, optionally also to a PSR cache implementation, to improve performance.
  *
+ * @phpstan-type RealpathCacheStorage array<string, RealpathCacheEntry>
  * @phpstan-type RealpathCacheEntry array{canonical?: string, exists?: bool, realpath?: string, symlink?: string}
  * @author Dan Phillimore <dan@ovms.co>
  */
 interface RealpathCacheInterface
 {
+    public const PRELOAD_CACHE_KEY = 'nytris.boost.preload.realpath';
+
     /**
      * Adds the given path (and all segments of the realpath) to the realpath cache.
      */
     public function cacheRealpath(string $canonicalPath, string $realpath): void;
+
+    /**
+     * Deletes the entry for the specified realpath from the in-memory and PSR backing caches.
+     */
+    public function deleteBackingCacheEntry(string $realpath): void;
+
+    /**
+     * Fetches the entry for the given realpath from the in-memory or PSR backing cache, if any.
+     *
+     * @param string $realpath
+     * @return array<mixed>|null
+     */
+    public function getBackingCacheEntry(string $realpath): ?array;
 
     /**
      * Fetches the realpath for the given path if cached, even if its existence is not known.
@@ -45,6 +61,13 @@ interface RealpathCacheInterface
         bool $followSymlinks = true,
         bool &$accessible = true
     ): string;
+
+    /**
+     * Fetches the in-memory realpath entry cache.
+     *
+     * @return RealpathCacheStorage
+     */
+    public function getInMemoryEntryCache(): array;
 
     /**
      * Fetches the realpath for the given path if cached,
@@ -81,4 +104,20 @@ interface RealpathCacheInterface
      * Persists the current realpath cache via configured PSR cache.
      */
     public function persistRealpathCache(): void;
+
+    /**
+     * Stores the given entry for the specified realpath in the in-memory and PSR backing caches.
+     *
+     * @param string $realpath
+     * @param RealpathCacheEntry $entry
+     */
+    public function setBackingCacheEntry(string $realpath, array $entry): void;
+
+    /**
+     * Stores the given entry for the specified realpath in the in-memory cache only.
+     *
+     * @param string $realpath
+     * @param RealpathCacheEntry $entry
+     */
+    public function setInMemoryCacheEntry(string $realpath, array $entry): void;
 }

--- a/src/FsCache/Stat/StatCache.php
+++ b/src/FsCache/Stat/StatCache.php
@@ -1,0 +1,468 @@
+<?php
+
+/*
+ * Nytris Boost
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\FsCache\Stat;
+
+use Asmblah\PhpCodeShift\Shifter\Stream\Handler\StreamHandlerInterface;
+use Asmblah\PhpCodeShift\Shifter\Stream\Native\StreamWrapperInterface;
+use LogicException;
+use Nytris\Boost\Environment\EnvironmentInterface;
+use Nytris\Boost\FsCache\CanonicaliserInterface;
+use Nytris\Boost\FsCache\Realpath\RealpathCacheInterface;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+/**
+ * Class StatCache.
+ *
+ * Caches filesystem stats, optionally also to a PSR cache implementation,
+ * to improve performance.
+ *
+ * @phpstan-import-type StatCacheStorage from StatCacheInterface
+ * @phpstan-import-type StatCacheEntry from StatCacheInterface
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class StatCache implements StatCacheInterface
+{
+    private int $startTime;
+    /**
+     * @var StatCacheStorage
+     */
+    private array $statCacheForIncludes = [];
+    /**
+     * @var StatCacheStorage
+     */
+    private array $statCacheForNonIncludes = [];
+    private bool $statCacheIsDirty = false;
+    private ?CacheItemInterface $statCachePoolItemForIncludes = null;
+    private ?CacheItemInterface $statCachePoolItemForNonIncludes = null;
+
+    public function __construct(
+        private readonly StreamHandlerInterface $wrappedStreamHandler,
+        EnvironmentInterface $environment,
+        private readonly CanonicaliserInterface $canonicaliser,
+        private readonly RealpathCacheInterface $realpathCache,
+        private readonly ?CacheItemPoolInterface $statCachePool,
+        string $statCacheKey,
+        private readonly bool $asVirtualFilesystem
+    ) {
+        $this->startTime = (int) $environment->getStartTime();
+
+        // Load the stat cache from the PSR cache if enabled.
+        if ($this->statCachePool !== null) {
+            $this->statCachePoolItemForIncludes = $this->statCachePool->getItem($statCacheKey . '_includes');
+
+            if ($this->statCachePoolItemForIncludes->isHit()) {
+                $this->statCacheForIncludes = $this->statCachePoolItemForIncludes->get();
+            }
+
+            $this->statCachePoolItemForNonIncludes = $this->statCachePool->getItem($statCacheKey . '_plain');
+
+            if ($this->statCachePoolItemForNonIncludes->isHit()) {
+                $this->statCacheForNonIncludes = $this->statCachePoolItemForNonIncludes->get();
+            }
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getCachedStat(
+        string $path,
+        bool $isLinkStat,
+        bool $isInclude,
+        bool &$accessible = true,
+        string &$linkPath = null
+    ): ?array {
+        // Link status fetches (lstat()s) stat the symlink file itself (if one exists at the given path)
+        // vs. stat() which stats the eventual file that the symlink points to.
+        $linkPath = $this->realpathCache->getCachedEventualPath(
+            $path,
+            followSymlinks: !$isLinkStat,
+            accessible: $accessible
+        );
+
+        if (!$accessible) {
+            // File is explicitly cached as non-existent.
+            return null;
+        }
+
+        if ($isInclude) {
+            $effectiveStatCache =& $this->statCacheForIncludes;
+        } else {
+            $effectiveStatCache =& $this->statCacheForNonIncludes;
+        }
+
+        if (array_key_exists($linkPath, $effectiveStatCache)) {
+            // Stat is already cached: just return it.
+            $accessible = true;
+
+            return $effectiveStatCache[$linkPath];
+        }
+
+        // Not cached; we have no way of knowing whether it is accessible,
+        // so we just assume it is for now until resolved by the backing store.
+        $accessible = true;
+
+        return null;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getPathStat(string $path, bool $isLinkStat, bool $quiet = true): ?array
+    {
+        $accessible = true;
+        $linkPath = null;
+        $stat = $this->getCachedStat(
+            $path,
+            isLinkStat: $isLinkStat,
+            isInclude: false,
+            accessible: $accessible,
+            linkPath: $linkPath
+        );
+
+        if ($stat !== null) {
+            return $stat;
+        }
+
+        if (!$accessible) {
+            // Path has been cached as non-accessible.
+            return null;
+        }
+
+        if ($this->asVirtualFilesystem) {
+            // The stat should not hit the backing store.
+            return null;
+        }
+
+        $stat = $this->wrappedStreamHandler->urlStat(
+            $path,
+            flags: ($isLinkStat ? STREAM_URL_STAT_LINK : 0) | ($quiet ? STREAM_URL_STAT_QUIET : 0)
+        );
+
+        if ($stat === false) {
+            // Stat failed.
+            return null;
+        }
+
+        // Cache stat for future reference.
+        $this->statCacheForNonIncludes[$linkPath] = $this->statToSynthetic($stat);
+        $this->statCacheIsDirty = true;
+
+        return $stat;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getStreamStat(StreamWrapperInterface $streamWrapper): ?array
+    {
+        $linkPath = null;
+        $stat = $this->getCachedStat(
+            $streamWrapper->getOpenPath(),
+            isLinkStat: false,
+            isInclude: $streamWrapper->isInclude(),
+            linkPath: $linkPath
+        );
+
+        if ($stat !== null) {
+            // Stat is already cached: just return it.
+            return $stat;
+        }
+
+        if ($this->asVirtualFilesystem) {
+            // The stat should not hit the backing store.
+            return null;
+        }
+
+        $stat = $this->wrappedStreamHandler->streamStat($streamWrapper);
+
+        if ($stat === false) {
+            // Stat failed.
+            return null;
+        }
+
+        if ($streamWrapper->isInclude()) {
+            $effectiveStatCache =& $this->statCacheForIncludes;
+        } else {
+            $effectiveStatCache =& $this->statCacheForNonIncludes;
+        }
+
+        // Cache stat for future reference.
+        $effectiveStatCache[$linkPath] = $this->statToSynthetic($stat);
+        $this->statCacheIsDirty = true;
+
+        return $stat;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function invalidate(): void
+    {
+        $this->statCacheForIncludes = [];
+        $this->statCacheForNonIncludes = [];
+
+        $this->statCacheIsDirty = true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function invalidatePath(string $path): void
+    {
+        // Clear the canonical path entries.
+        $canonicalPath = $this->canonicaliser->canonicalise($path);
+
+        unset(
+            $this->statCacheForIncludes[$canonicalPath],
+            $this->statCacheForNonIncludes[$canonicalPath]
+        );
+
+        // Clear the eventual path entries if not cleared above.
+        $eventualPath = $this->realpathCache->getCachedEventualPath($path);
+        unset(
+            $this->statCacheForIncludes[$eventualPath],
+            $this->statCacheForNonIncludes[$eventualPath]
+        );
+
+        $this->statCacheIsDirty = true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function isDirectory(string $path): bool
+    {
+        $stat = $this->getCachedStat($path, isLinkStat: false, isInclude: false);
+
+        return $stat !== null && ($stat['mode'] & 0040000);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function persistStatCache(): void
+    {
+        if ($this->statCachePoolItemForIncludes === null || $this->statCacheIsDirty === false) {
+            return; // Persistence is disabled or nothing changed; nothing to do.
+        }
+
+        $this->statCachePoolItemForIncludes->set($this->statCacheForIncludes);
+        $this->statCachePoolItemForNonIncludes->set($this->statCacheForNonIncludes);
+        $this->statCachePool->saveDeferred($this->statCachePoolItemForIncludes);
+        $this->statCachePool->saveDeferred($this->statCachePoolItemForNonIncludes);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function populateStatWithSize(
+        string $realpath,
+        int $size,
+        bool $isInclude
+    ): void {
+        if ($isInclude) {
+            $effectiveStatCache =& $this->statCacheForIncludes;
+        } else {
+            $effectiveStatCache =& $this->statCacheForNonIncludes;
+        }
+
+        if (array_key_exists($realpath, $effectiveStatCache)) {
+            // Already cached - just update the size if needed.
+            $effectiveStatCache[$realpath]['size'] = $size;
+            $effectiveStatCache[$realpath][7] = $size;
+
+            return;
+        }
+
+        // Note that we cannot stat the open stream, as it may be a `php://memory` stream
+        // rather than the original, e.g. if it was shifted.
+        // This may be served from cache if previously performed by a non-include stat.
+        $nonIncludeStat = $this->getPathStat($realpath, isLinkStat: false);
+
+        if ($nonIncludeStat === null) {
+            if (!$this->asVirtualFilesystem) {
+                throw new LogicException('Cannot stat original realpath "' . $realpath . '"');
+            }
+
+            $this->synthesiseStat(
+                $realpath,
+                isInclude: $isInclude,
+                isDir: false,
+                mode: 0777,
+                // Ensure we use the size of the potentially shifted contents and not the original.
+                size: $size
+            );
+
+            return;
+        }
+
+        $includeStat = $this->statToSynthetic([...$nonIncludeStat, 'size' => $size]);
+
+        $effectiveStatCache[$realpath] = $includeStat;
+        $this->statCacheIsDirty = true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function setStat(string $realpath, array $stat, bool $isInclude): void
+    {
+        if ($isInclude) {
+            $effectiveStatCache =& $this->statCacheForIncludes;
+        } else {
+            $effectiveStatCache =& $this->statCacheForNonIncludes;
+        }
+
+        $effectiveStatCache[$realpath] = $this->statToSynthetic($stat);
+
+        $this->statCacheIsDirty = true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function statToSynthetic(array $stat): array
+    {
+        $syntheticStat = [
+            'dev' => 0,
+            'ino' => 0,
+            'mode' => $stat['mode'],
+            'nlink' => 0,
+            'uid' => $stat['uid'],
+            'gid' => $stat['gid'],
+            'rdev' => 0,
+            'size' => $stat['size'],
+            'atime' => $stat['atime'],
+            'mtime' => $stat['mtime'],
+            'ctime' => $stat['ctime'],
+            'blksize' => -1,
+            'blocks' => -1,
+        ];
+
+        // Stat elements are also available in the above order under indexed keys.
+        return array_merge(array_values($syntheticStat), $syntheticStat);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function synthesiseStat(
+        string $realpath,
+        bool $isInclude,
+        bool $isDir,
+        int $mode,
+        int $size
+    ): void {
+        if (!$this->asVirtualFilesystem) {
+            throw new LogicException(
+                'Cannot use fully synthetic stats outside of a virtual filesystem'
+            );
+        }
+
+        if ($isInclude) {
+            $effectiveStatCache =& $this->statCacheForIncludes;
+        } else {
+            $effectiveStatCache =& $this->statCacheForNonIncludes;
+        }
+
+        if (array_key_exists($realpath, $effectiveStatCache)) {
+            throw new LogicException('Synthetic stat already exists for path "' . $realpath . '"');
+        }
+
+        $stat = $this->statToSynthetic([
+            'mode' => ($isDir ? 0040000 : 0100000) | 0777,
+            'uid' => 0,
+            'gid' => 0,
+            // Ensure we use a past timestamp to ensure PHP files are cached
+            // when `opcache.file_update_protection` is enabled.
+            'atime' => $this->startTime - 10,
+            'mtime' => $this->startTime - 10,
+            'ctime' => $this->startTime - 10,
+            'size' => $size,
+        ]);
+
+        $effectiveStatCache[$realpath] = $stat;
+        $this->statCacheIsDirty = true;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function updateSyntheticStat(
+        string $realpath,
+        bool $isInclude,
+        ?int $mode = null,
+        ?int $size = null,
+        ?int $modificationTime = null,
+        ?int $accessTime = null,
+        ?int $uid = null,
+        ?int $gid = null
+    ): void {
+        if (!$this->asVirtualFilesystem) {
+            throw new LogicException(
+                'Cannot use fully synthetic stats outside of a virtual filesystem'
+            );
+        }
+
+        if ($isInclude) {
+            $effectiveStatCache =& $this->statCacheForIncludes;
+        } else {
+            $effectiveStatCache =& $this->statCacheForNonIncludes;
+        }
+
+        if (!array_key_exists($realpath, $effectiveStatCache)) {
+            throw new LogicException('No synthetic stat exists for path "' . $realpath . '"');
+        }
+
+        // Update the stat components as needed.
+        $stat =& $effectiveStatCache[$realpath];
+
+        if ($size !== null) {
+            $stat['size'] = $size;
+            $stat[7] = $size;
+        }
+
+        if ($mode !== null) {
+            // Preserve the upper file type bits of the full mode.
+            $fullMode = ($stat['mode'] & 0777000) | ($mode & 0777);
+
+            $stat['mode'] = $fullMode;
+            $stat[2] = $fullMode;
+        }
+
+        if ($uid !== null) {
+            $stat['uid'] = $uid;
+            $stat[4] = $uid;
+        }
+
+        if ($gid !== null) {
+            $stat['gid'] = $gid;
+            $stat[5] = $gid;
+        }
+
+        if ($accessTime !== null) {
+            $stat['atime'] = $accessTime;
+            $stat[8] = $accessTime;
+        }
+
+        if ($modificationTime !== null) {
+            $stat['mtime'] = $modificationTime;
+            $stat[9] = $modificationTime;
+        }
+
+        $this->statCacheIsDirty = true;
+    }
+}

--- a/src/FsCache/Stat/StatCacheInterface.php
+++ b/src/FsCache/Stat/StatCacheInterface.php
@@ -1,0 +1,140 @@
+<?php
+
+/*
+ * Nytris Boost
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\FsCache\Stat;
+
+use Asmblah\PhpCodeShift\Shifter\Stream\Native\StreamWrapperInterface;
+
+/**
+ * Interface StatCacheInterface.
+ *
+ * Caches filesystem stats, optionally also to a PSR cache implementation,
+ * to improve performance.
+ *
+ * @phpstan-type StatCacheStorage array<string, StatCacheEntry>
+ * @phpstan-type StatCacheEntry array<mixed>
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+interface StatCacheInterface
+{
+    /**
+     * Fetches the (link)stat for the given path, only if already cached.
+     *
+     * @param string $path
+     * @param bool $isLinkStat
+     * @param bool $isInclude
+     * @param bool $accessible
+     * @param string|null $linkPath
+     * @return array<mixed>|null
+     */
+    public function getCachedStat(
+        string $path,
+        bool $isLinkStat,
+        bool $isInclude,
+        bool &$accessible = true,
+        string &$linkPath = null
+    ): ?array;
+
+    /**
+     * Fetches the (link)stat for the given path.
+     *
+     * TODO: Only accept realpaths (perhaps for all these methods), shifting responsibility to the caller?
+     *
+     * @param string $path
+     * @param bool $isLinkStat
+     * @param bool $quiet
+     * @return array<mixed>|null
+     */
+    public function getPathStat(string $path, bool $isLinkStat, bool $quiet = true): ?array;
+
+    /**
+     * Fetches the (link)stat for the given stream.
+     *
+     * @param StreamWrapperInterface $streamWrapper
+     * @return array<mixed>|null
+     */
+    public function getStreamStat(StreamWrapperInterface $streamWrapper): ?array;
+
+    /**
+     * Clears the stat cache.
+     */
+    public function invalidate(): void;
+
+    /**
+     * Clears the stat cache for the given path.
+     */
+    public function invalidatePath(string $path): void;
+
+    /**
+     * Determines whether the given path is a directory.
+     */
+    public function isDirectory(string $path): bool;
+
+    /**
+     * Persists the current stat cache via configured PSR cache.
+     */
+    public function persistStatCache(): void;
+
+    /**
+     * Populates the stat cache if it hasn't already been for the given realpath.
+     *
+     * In particular, for include stats we need:
+     * - The size to match that of the shifted code (if applicable) and not the original,
+     * - Timestamps to match, as OPcache won't cache streams with a modification date
+     *   after script start if `opcache.file_update_protection` is enabled.
+     */
+    public function populateStatWithSize(string $realpath, int $size, bool $isInclude): void;
+
+    /**
+     * Stores the given stat for the specified path.
+     *
+     * @param string $realpath
+     * @param array<mixed> $stat
+     * @param bool $isInclude
+     */
+    public function setStat(string $realpath, array $stat, bool $isInclude): void;
+
+    /**
+     * Converts the given stat to a synthetic one that is not bound to the original inode.
+     * This allows it to be persisted without causing strange issues.
+     *
+     * @param array<mixed> $stat
+     * @return array<mixed>
+     */
+    public function statToSynthetic(array $stat): array;
+
+    /**
+     * Creates a synthetic stat for a virtual filesystem.
+     */
+    public function synthesiseStat(
+        string $realpath,
+        bool $isInclude,
+        bool $isDir,
+        int $mode,
+        int $size
+    ): void;
+
+    /**
+     * Updates a stat previously created with `->synthesiseStat(...)`.
+     */
+    public function updateSyntheticStat(
+        string $realpath,
+        bool $isInclude,
+        ?int $mode = null,
+        ?int $size = null,
+        ?int $modificationTime = null,
+        ?int $accessTime = null,
+        ?int $uid = null,
+        ?int $gid = null
+    ): void;
+}

--- a/src/FsCache/Stat/StatCacheInterface.php
+++ b/src/FsCache/Stat/StatCacheInterface.php
@@ -21,12 +21,16 @@ use Asmblah\PhpCodeShift\Shifter\Stream\Native\StreamWrapperInterface;
  * Caches filesystem stats, optionally also to a PSR cache implementation,
  * to improve performance.
  *
+ * @phpstan-type MultipleStatCacheStorage array{include: StatCacheStorage, non_include: StatCacheStorage}
  * @phpstan-type StatCacheStorage array<string, StatCacheEntry>
  * @phpstan-type StatCacheEntry array<mixed>
  * @author Dan Phillimore <dan@ovms.co>
  */
 interface StatCacheInterface
 {
+    public const INCLUDE_PRELOAD_CACHE_KEY = 'nytris.boost.preload.stat.include';
+    public const NON_INCLUDE_PRELOAD_CACHE_KEY = 'nytris.boost.preload.stat.plain';
+
     /**
      * Fetches the (link)stat for the given path, only if already cached.
      *
@@ -44,6 +48,13 @@ interface StatCacheInterface
         bool &$accessible = true,
         string &$linkPath = null
     ): ?array;
+
+    /**
+     * Fetches the in-memory stat entry cache.
+     *
+     * @return MultipleStatCacheStorage
+     */
+    public function getInMemoryEntryCache(): array;
 
     /**
      * Fetches the (link)stat for the given path.
@@ -81,6 +92,11 @@ interface StatCacheInterface
     public function isDirectory(string $path): bool;
 
     /**
+     * Determines whether the given path has been cached as existent.
+     */
+    public function isPathCachedAsExistent(string $path): bool;
+
+    /**
      * Persists the current stat cache via configured PSR cache.
      */
     public function persistStatCache(): void;
@@ -94,6 +110,15 @@ interface StatCacheInterface
      *   after script start if `opcache.file_update_protection` is enabled.
      */
     public function populateStatWithSize(string $realpath, int $size, bool $isInclude): void;
+
+    /**
+     * Stores the given stat for the specified realpath in the in-memory cache only.
+     *
+     * @param string $realpath
+     * @param bool $isInclude
+     * @param array<mixed> $entry
+     */
+    public function setInMemoryCacheEntry(string $realpath, bool $isInclude, array $entry): void;
 
     /**
      * Stores the given stat for the specified path.

--- a/src/FsCache/Stream/Handler/FsCachingStreamHandler.php
+++ b/src/FsCache/Stream/Handler/FsCachingStreamHandler.php
@@ -305,9 +305,6 @@ class FsCachingStreamHandler extends AbstractStreamHandlerDecorator implements F
         if ($this->asVirtualFilesystem) {
             // TODO: Remove directory from realpath & stat caches (stat entry mode will indicate a dir).
             throw new LogicException('Nytris Boost :: rmdir() in virtual FS mode not yet supported');
-
-            // The rmdir should not hit the backing store.
-            return true;
         }
 
         $this->invalidatePath($path);
@@ -491,10 +488,10 @@ class FsCachingStreamHandler extends AbstractStreamHandlerDecorator implements F
         }
 
         if ($this->asVirtualFilesystem) {
-            // TODO: Remove file from realpath, stat & contents caches.
-            throw new LogicException('Nytris Boost :: unlink() in virtual FS mode not yet supported');
+            $this->statCache->invalidatePath($eventualPath);
+            $this->contentsCache->invalidatePath($eventualPath);
+            $this->realpathCache->invalidatePath($eventualPath);
 
-            // The unlink should not hit the backing store.
             return true;
         }
 

--- a/src/FsCache/Stream/Handler/FsCachingStreamHandlerInterface.php
+++ b/src/FsCache/Stream/Handler/FsCachingStreamHandlerInterface.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Nytris\Boost\FsCache\Stream\Handler;
 
 use Asmblah\PhpCodeShift\Shifter\Stream\Handler\StreamHandlerInterface;
+use Nytris\Boost\FsCache\Realpath\RealpathCacheInterface;
+use Nytris\Boost\FsCache\Stat\StatCacheInterface;
 
 /**
  * Interface FsCachingStreamHandlerInterface.
@@ -21,10 +23,8 @@ use Asmblah\PhpCodeShift\Shifter\Stream\Handler\StreamHandlerInterface;
  * Caches realpath and filesystem stats, optionally also to a PSR cache implementation,
  * to improve performance.
  *
- * @phpstan-type RealpathCache array<string, RealpathCacheEntry>
- * @phpstan-type RealpathCacheEntry array{canonical?: string, exists?: bool, realpath?: string, symlink?: string}
- * @phpstan-type StatCache array<string, StatCacheEntry>
- * @phpstan-type StatCacheEntry array<mixed>
+ * @phpstan-import-type MultipleStatCacheStorage from StatCacheInterface
+ * @phpstan-import-type RealpathCacheStorage from RealpathCacheInterface
  * @author Dan Phillimore <dan@ovms.co>
  */
 interface FsCachingStreamHandlerInterface extends StreamHandlerInterface
@@ -38,6 +38,20 @@ interface FsCachingStreamHandlerInterface extends StreamHandlerInterface
      * Fetches the realpath for the given path, even if it does not exist.
      */
     public function getEventualPath(string $path): string;
+
+    /**
+     * Fetches the in-memory realpath entry cache.
+     *
+     * @return RealpathCacheStorage
+     */
+    public function getInMemoryRealpathEntryCache(): array;
+
+    /**
+     * Fetches the in-memory stat entry cache.
+     *
+     * @return MultipleStatCacheStorage
+     */
+    public function getInMemoryStatEntryCache(): array;
 
     /**
      * Fetches the realpath for the given path if cached,

--- a/src/FsCache/Stream/Handler/FsCachingStreamHandlerInterface.php
+++ b/src/FsCache/Stream/Handler/FsCachingStreamHandlerInterface.php
@@ -46,15 +46,6 @@ interface FsCachingStreamHandlerInterface extends StreamHandlerInterface
     public function getRealpath(string $path): ?string;
 
     /**
-     * Fetches the realpath cache entry for the given path if cached,
-     * or null otherwise.
-     *
-     * @param string $path
-     * @return RealpathCacheEntry|null
-     */
-    public function getRealpathCacheEntry(string $path): ?array;
-
-    /**
      * Clears the realpath and stat caches.
      *
      * Note that this does not affect the contents cache.
@@ -75,14 +66,4 @@ interface FsCachingStreamHandlerInterface extends StreamHandlerInterface
      * Persists the current stat cache via configured PSR cache.
      */
     public function persistStatCache(): void;
-
-    /**
-     * Populates the stat cache for an include if it hasn't already been.
-     *
-     * In particular, we need:
-     * - The size to match that of the shifted code (if applicable) and not the original,
-     * - Timestamps to match, as OPcache won't cache streams with a modification date
-     *   after script start if `opcache.file_update_protection` is enabled.
-     */
-    public function synthesiseIncludeStat(string $realpath, int $size): void;
 }

--- a/src/FsCache/Stream/Handler/FsCachingStreamHandlerInterface.php
+++ b/src/FsCache/Stream/Handler/FsCachingStreamHandlerInterface.php
@@ -55,12 +55,14 @@ interface FsCachingStreamHandlerInterface extends StreamHandlerInterface
     public function getRealpathCacheEntry(string $path): ?array;
 
     /**
-     * Clears both the realpath and stat caches.
+     * Clears the realpath and stat caches.
+     *
+     * Note that this does not affect the contents cache.
      */
     public function invalidateCaches(): void;
 
     /**
-     * Clears both the realpath and stat caches for the given path.
+     * Clears the realpath, stat and contents caches for the given path.
      */
     public function invalidatePath(string $path): void;
 
@@ -73,4 +75,14 @@ interface FsCachingStreamHandlerInterface extends StreamHandlerInterface
      * Persists the current stat cache via configured PSR cache.
      */
     public function persistStatCache(): void;
+
+    /**
+     * Populates the stat cache for an include if it hasn't already been.
+     *
+     * In particular, we need:
+     * - The size to match that of the shifted code (if applicable) and not the original,
+     * - Timestamps to match, as OPcache won't cache streams with a modification date
+     *   after script start if `opcache.file_update_protection` is enabled.
+     */
+    public function synthesiseIncludeStat(string $realpath, int $size): void;
 }

--- a/src/FsCache/Stream/Opener/StreamOpener.php
+++ b/src/FsCache/Stream/Opener/StreamOpener.php
@@ -15,9 +15,12 @@ namespace Nytris\Boost\FsCache\Stream\Opener;
 
 use Asmblah\PhpCodeShift\Shifter\Stream\Handler\StreamHandlerInterface;
 use Asmblah\PhpCodeShift\Shifter\Stream\Native\StreamWrapperInterface;
-use Nytris\Boost\FsCache\CanonicaliserInterface;
+use LogicException;
+use Nytris\Boost\FsCache\Contents\CachedFileInterface;
 use Nytris\Boost\FsCache\Contents\ContentsCacheInterface;
-use Nytris\Boost\FsCache\Stream\Handler\FsCachingStreamHandlerInterface;
+use Nytris\Boost\FsCache\Realpath\RealpathCacheInterface;
+use Nytris\Boost\FsCache\Stat\StatCacheInterface;
+use WeakMap;
 
 /**
  * Class StreamOpener.
@@ -28,11 +31,86 @@ use Nytris\Boost\FsCache\Stream\Handler\FsCachingStreamHandlerInterface;
  */
 class StreamOpener implements StreamOpenerInterface
 {
+    /**
+     * @var WeakMap<StreamWrapperInterface, array{cachedFile: CachedFileInterface, path: string}>
+     */
+    private WeakMap $writeStreamData;
+
     public function __construct(
         private readonly StreamHandlerInterface $wrappedStreamHandler,
-        private readonly CanonicaliserInterface $canonicaliser,
-        private readonly ?ContentsCacheInterface $contentsCache
+        private readonly RealpathCacheInterface $realpathCache,
+        private readonly StatCacheInterface $statCache,
+        private readonly ?ContentsCacheInterface $contentsCache,
+        private readonly bool $asVirtualFilesystem
     ) {
+        $this->writeStreamData = new WeakMap();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function flushStream(
+        StreamWrapperInterface $streamWrapper
+    ): bool {
+        if (!$this->asVirtualFilesystem || !$this->contentsCache) {
+            return $this->wrappedStreamHandler->streamFlush($streamWrapper);
+        }
+
+        // Virtual filesystem mode - write contents of stream to contents cache if applicable.
+        $writeStreamData = $this->writeStreamData[$streamWrapper] ?? null;
+
+        if ($writeStreamData === null) {
+            // Stream is not open for writing to a file in the virtual filesystem.
+            return true;
+        }
+
+        ['cachedFile' => $cachedFile, 'path' => $path] = $writeStreamData;
+
+        $resource = $streamWrapper->getWrappedResource();
+
+        // TODO: Confirm whether this check is needed - if opened in read-only mode, will flush hook ever be called,
+        //       even on fflush(...)?
+        $mode = $streamWrapper->getOpenMode();
+        $isRead = str_contains($mode, 'r') && !str_contains($mode, '+');
+
+        if (!$isRead) {
+            $position = ftell($resource);
+
+            if ($position === false) {
+                // Stream cannot be flushed as we cannot even read its current position.
+                return false;
+            }
+
+            // Flushing the `php://memory` stream is probably not required, but included for completeness.
+            if (fflush($resource) === false) {
+                return false;
+            }
+
+            // Rewind as the stream is likely to currently be seeked following writes.
+            rewind($resource);
+            $contents = stream_get_contents($resource);
+
+            // Seek back to the original position following the read just above.
+            if (fseek($resource, $position) === -1) {
+                return false;
+            }
+
+            $cachedFile->setContents($contents);
+
+            try {
+                $this->statCache->updateSyntheticStat(
+                    $path,
+                    isInclude: false,
+                    size: strlen($contents)
+                );
+            } catch (LogicException) {
+                return false;
+            }
+        }
+
+        unset($this->writeStreamData[$streamWrapper]);
+
+        return true;
     }
 
     /**
@@ -43,32 +121,97 @@ class StreamOpener implements StreamOpenerInterface
         string $path,
         string $mode,
         int $options,
-        ?string &$openedPath,
-        FsCachingStreamHandlerInterface $streamHandler
+        ?string &$openedPath
     ): ?array {
         $isRead = str_contains($mode, 'r') && !str_contains($mode, '+');
 
         if ($isRead) {
-            $effectivePath = $streamHandler->getRealpath($path);
+            $effectivePath = $this->realpathCache->getRealpath($path);
 
             if ($effectivePath === null) {
                 return null;
             }
         } else {
-            $effectivePath = $this->canonicaliser->canonicalise($path);
+            $effectivePath = $path;
 
-            // File is being written to, so clear cache (e.g. in case it was cached as non-existent).
-            $streamHandler->invalidatePath($effectivePath);
+            if (!$this->asVirtualFilesystem) {
+                // File is being written to, so clear cache (e.g. in case it was cached as non-existent).
+                $this->realpathCache->invalidatePath($effectivePath);
+                $this->statCache->invalidatePath($effectivePath);
+                $this->contentsCache?->invalidatePath($effectivePath);
+            }
         }
 
         if ($this->contentsCache === null) {
+            if ($this->asVirtualFilesystem) {
+                // File contents access is impossible in virtual filesystem mode with no contents cache,
+                // as there is nowhere to store or retrieve file contents from.
+                return null;
+            }
+
             // Contents cache is disabled, so ignore.
             return $this->wrappedStreamHandler->streamOpen($streamWrapper, $effectivePath, $mode, $options, $openedPath);
         }
 
         if (!$isRead) {
+            if ($this->asVirtualFilesystem) {
+                // Load file contents from the contents cache if possible.
+                $cachedFile = $this->contentsCache->getItemForPath($effectivePath, isInclude: false);
+
+                $writeStream = fopen('php://memory', 'rb+');
+
+                if ($cachedFile->isCached()) {
+                    // Read current contents from contents cache into stream, if any.
+                    $contents = $cachedFile->getContents();
+
+                    fwrite($writeStream, $contents);
+
+                    // Unless we're opening for append, rewind the stream pointer to the beginning.
+                    if (!str_contains($mode, 'a')) {
+                        rewind($writeStream);
+                    }
+
+                    $this->statCache->updateSyntheticStat(
+                        $effectivePath,
+                        isInclude: false,
+                        size: strlen($contents)
+                    );
+                } else {
+                    // File is newly created and therefore empty.
+                    $cachedFile->setContents('');
+
+                    $this->statCache->synthesiseStat(
+                        $effectivePath,
+                        isInclude: false,
+                        isDir: false,
+                        mode: 0777,
+                        size: 0,
+                    );
+                }
+
+                $this->writeStreamData[$streamWrapper] = [
+                    'cachedFile' => $cachedFile,
+                    'path' => $effectivePath,
+                ];
+
+                return [
+                    'resource' => $writeStream,
+                    'isInclude' => false, // Cannot be an include in write mode.
+                ];
+            }
+
             // We are opening for write, so ignore - contents cache will have been cleared above.
             return $this->wrappedStreamHandler->streamOpen($streamWrapper, $effectivePath, $mode, $options, $openedPath);
+        }
+
+        if ($this->statCache->isDirectory($effectivePath)) {
+            // When opening a directory as a stream, it is not actually readable or writable.
+            // TODO: Raise `Read of 8192 bytes failed with errno=21 Is a directory` on read etc.
+
+            return [
+                'resource' => fopen('php://memory', 'rb+'),
+                'isInclude' => false, // Cannot be an include of a directory.
+            ];
         }
 
         $isInclude = $this->wrappedStreamHandler->isInclude($options);
@@ -88,9 +231,13 @@ class StreamOpener implements StreamOpenerInterface
                 /*
                  * Populate the stat cache for the include if it hasn't already been.
                  *
-                 * See notes in `->synthesiseIncludeStat(...)`.
+                 * See notes in `->synthesiseStat(...)`.
                  */
-                $streamHandler->synthesiseIncludeStat($effectivePath, strlen($contents));
+                $this->statCache->populateStatWithSize(
+                    $effectivePath,
+                    strlen($contents),
+                    isInclude: true
+                );
             }
 
             $usePath = (bool) ($options & STREAM_USE_PATH);
@@ -104,16 +251,45 @@ class StreamOpener implements StreamOpenerInterface
             return ['resource' => $cacheStream, 'isInclude' => $isInclude];
         }
 
-        // Contents are not yet cached - forward to the wrapped handler,
-        // which will also apply any applicable shifts.
-        $result = $this->wrappedStreamHandler->streamOpen(
-            $streamWrapper,
-            $effectivePath,
-            $mode,
-            $options,
-            $openedPath
-        );
-        $sourceStream = $result['resource'];
+        if ($this->asVirtualFilesystem) {
+            if (!$isInclude) {
+                // File is not cached - if we had tried the include variant then we could fall back
+                // to the non-include variant and apply any shifts, but this file does not exist at all.
+                return null;
+            }
+
+            // Attempt to read the non-shifted variant of the file.
+            $cachedFile = $this->contentsCache->getItemForPath($effectivePath, isInclude: false);
+
+            if (!$cachedFile->isCached()) {
+                // File does not exist in the virtual filesystem at all.
+                return null;
+            }
+
+            $nonIncludeStream = fopen('php://memory', 'rb+');
+            fwrite($nonIncludeStream, $cachedFile->getContents());
+            rewind($nonIncludeStream);
+
+            $sourceStream = $this->wrappedStreamHandler->shiftFile(
+                $effectivePath,
+                fn () => $nonIncludeStream
+            );
+
+            if ($sourceStream === null) {
+                // Failed to shift the file for some reason.
+                return null;
+            }
+        } else {
+            // In caching mode rather than virtual filesystem mode, and contents are not yet cached -
+            // forward to the wrapped handler, which will also apply any applicable shifts.
+            ['resource' => $sourceStream] = $this->wrappedStreamHandler->streamOpen(
+                $streamWrapper,
+                $effectivePath,
+                $mode,
+                $options,
+                $openedPath
+            );
+        }
 
         $contents = stream_get_contents($sourceStream);
 
@@ -129,9 +305,13 @@ class StreamOpener implements StreamOpenerInterface
              *
              * See notes in `->synthesiseIncludeStat(...)`.
              */
-            $streamHandler->synthesiseIncludeStat($effectivePath, strlen($contents));
+            $this->statCache->populateStatWithSize(
+                $effectivePath,
+                strlen($contents),
+                isInclude: true
+            );
         }
 
-        return $result;
+        return ['resource' => $sourceStream, 'isInclude' => $isInclude];
     }
 }

--- a/src/FsCache/Stream/Opener/StreamOpener.php
+++ b/src/FsCache/Stream/Opener/StreamOpener.php
@@ -1,0 +1,137 @@
+<?php
+
+/*
+ * Nytris Boost
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\FsCache\Stream\Opener;
+
+use Asmblah\PhpCodeShift\Shifter\Stream\Handler\StreamHandlerInterface;
+use Asmblah\PhpCodeShift\Shifter\Stream\Native\StreamWrapperInterface;
+use Nytris\Boost\FsCache\CanonicaliserInterface;
+use Nytris\Boost\FsCache\Contents\ContentsCacheInterface;
+use Nytris\Boost\FsCache\Stream\Handler\FsCachingStreamHandlerInterface;
+
+/**
+ * Class StreamOpener.
+ *
+ * Opens a file stream, handling contents caching if applicable.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class StreamOpener implements StreamOpenerInterface
+{
+    public function __construct(
+        private readonly StreamHandlerInterface $wrappedStreamHandler,
+        private readonly CanonicaliserInterface $canonicaliser,
+        private readonly ?ContentsCacheInterface $contentsCache
+    ) {
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function openStream(
+        StreamWrapperInterface $streamWrapper,
+        string $path,
+        string $mode,
+        int $options,
+        ?string &$openedPath,
+        FsCachingStreamHandlerInterface $streamHandler
+    ): ?array {
+        $isRead = str_contains($mode, 'r') && !str_contains($mode, '+');
+
+        if ($isRead) {
+            $effectivePath = $streamHandler->getRealpath($path);
+
+            if ($effectivePath === null) {
+                return null;
+            }
+        } else {
+            $effectivePath = $this->canonicaliser->canonicalise($path);
+
+            // File is being written to, so clear cache (e.g. in case it was cached as non-existent).
+            $streamHandler->invalidatePath($effectivePath);
+        }
+
+        if ($this->contentsCache === null) {
+            // Contents cache is disabled, so ignore.
+            return $this->wrappedStreamHandler->streamOpen($streamWrapper, $effectivePath, $mode, $options, $openedPath);
+        }
+
+        if (!$isRead) {
+            // We are opening for write, so ignore - contents cache will have been cleared above.
+            return $this->wrappedStreamHandler->streamOpen($streamWrapper, $effectivePath, $mode, $options, $openedPath);
+        }
+
+        $isInclude = $this->wrappedStreamHandler->isInclude($options);
+
+        $cachedFile = $this->contentsCache->getItemForPath($effectivePath, $isInclude);
+
+        if ($cachedFile->isCached()) {
+            // File's contents are cached, so we can serve it without hitting the filesystem.
+
+            $cacheStream = fopen('php://memory', 'rb+');
+            $contents = $cachedFile->getContents();
+
+            fwrite($cacheStream, $contents);
+            rewind($cacheStream);
+
+            if ($isInclude) {
+                /*
+                 * Populate the stat cache for the include if it hasn't already been.
+                 *
+                 * See notes in `->synthesiseIncludeStat(...)`.
+                 */
+                $streamHandler->synthesiseIncludeStat($effectivePath, strlen($contents));
+            }
+
+            $usePath = (bool) ($options & STREAM_USE_PATH);
+
+            if ($usePath && $openedPath) {
+                // This is usually done by the original StreamHandler, but when contents are cached
+                // we do not return to there.
+                $openedPath = $effectivePath;
+            }
+
+            return ['resource' => $cacheStream, 'isInclude' => $isInclude];
+        }
+
+        // Contents are not yet cached - forward to the wrapped handler,
+        // which will also apply any applicable shifts.
+        $result = $this->wrappedStreamHandler->streamOpen(
+            $streamWrapper,
+            $effectivePath,
+            $mode,
+            $options,
+            $openedPath
+        );
+        $sourceStream = $result['resource'];
+
+        $contents = stream_get_contents($sourceStream);
+
+        // Now rewind the stream after reading its contents just above,
+        // so that it can be reused for the current stream wrapper.
+        rewind($sourceStream);
+
+        $cachedFile->setContents($contents);
+
+        if ($isInclude) {
+            /*
+             * Populate the stat cache for the include if it hasn't already been.
+             *
+             * See notes in `->synthesiseIncludeStat(...)`.
+             */
+            $streamHandler->synthesiseIncludeStat($effectivePath, strlen($contents));
+        }
+
+        return $result;
+    }
+}

--- a/src/FsCache/Stream/Opener/StreamOpenerInterface.php
+++ b/src/FsCache/Stream/Opener/StreamOpenerInterface.php
@@ -14,7 +14,6 @@ declare(strict_types=1);
 namespace Nytris\Boost\FsCache\Stream\Opener;
 
 use Asmblah\PhpCodeShift\Shifter\Stream\Native\StreamWrapperInterface;
-use Nytris\Boost\FsCache\Stream\Handler\FsCachingStreamHandlerInterface;
 
 /**
  * Interface StreamOpenerInterface.
@@ -25,6 +24,13 @@ use Nytris\Boost\FsCache\Stream\Handler\FsCachingStreamHandlerInterface;
  */
 interface StreamOpenerInterface
 {
+    /**
+     * Flushes an open stream.
+     */
+    public function flushStream(
+        StreamWrapperInterface $streamWrapper
+    ): bool;
+
     /**
      * Opens a stream to the given file.
      *
@@ -38,7 +44,6 @@ interface StreamOpenerInterface
         string $path,
         string $mode,
         int $options,
-        ?string &$openedPath,
-        FsCachingStreamHandlerInterface $streamHandler
+        ?string &$openedPath
     ): ?array;
 }

--- a/src/FsCache/Stream/Opener/StreamOpenerInterface.php
+++ b/src/FsCache/Stream/Opener/StreamOpenerInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * Nytris Boost
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\FsCache\Stream\Opener;
+
+use Asmblah\PhpCodeShift\Shifter\Stream\Native\StreamWrapperInterface;
+use Nytris\Boost\FsCache\Stream\Handler\FsCachingStreamHandlerInterface;
+
+/**
+ * Interface StreamOpenerInterface.
+ *
+ * Opens a file stream, handling contents caching if applicable.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+interface StreamOpenerInterface
+{
+    /**
+     * Opens a stream to the given file.
+     *
+     * Returns both the opened stream resource and whether this is an include vs. normal file access on success.
+     * Returns null on failure.
+     *
+     * @return array{resource: resource|null, isInclude: bool}|null
+     */
+    public function openStream(
+        StreamWrapperInterface $streamWrapper,
+        string $path,
+        string $mode,
+        int $options,
+        ?string &$openedPath,
+        FsCachingStreamHandlerInterface $streamHandler
+    ): ?array;
+}

--- a/src/Library/Library.php
+++ b/src/Library/Library.php
@@ -13,21 +13,115 @@ declare(strict_types=1);
 
 namespace Nytris\Boost\Library;
 
+use Asmblah\PhpCodeShift\CodeShift;
+use Asmblah\PhpCodeShift\CodeShiftInterface;
+use Asmblah\PhpCodeShift\Shifter\Filter\FileFilterInterface;
+use Asmblah\PhpCodeShift\Shifter\Shift\Shift\FunctionHook\FunctionHookShiftSpec;
 use Nytris\Boost\BoostInterface;
+use Nytris\Boost\Environment\Environment;
+use Nytris\Boost\Environment\EnvironmentInterface;
+use SplObjectStorage;
 
 /**
  * Class Library.
  *
- * Encapsulates an installation of the library as a Nytris package.
+ * Encapsulates an installation of the library.
  *
  * @author Dan Phillimore <dan@ovms.co>
  */
 class Library implements LibraryInterface
 {
+    /**
+     * @var SplObjectStorage<BoostInterface, void>
+     */
+    private SplObjectStorage $boosts;
+
     public function __construct(
-        private readonly BoostInterface $boost
+        private readonly EnvironmentInterface $environment = new Environment(),
+        private readonly CodeShiftInterface $codeShift = new CodeShift()
     ) {
-        $boost->install();
+        $this->boosts = new SplObjectStorage();
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function addBoost(BoostInterface $boost): void
+    {
+        $this->boosts->attach($boost);
+
+        if (count($this->boosts) === 1) {
+            $this->codeShift->install();
+        }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getEnvironment(): EnvironmentInterface
+    {
+        return $this->environment;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function hookBuiltinFunctions(FileFilterInterface $fileFilter): void
+    {
+        // Hook the `clearstatcache()` function and simply have it fully clear both caches
+        // in all installed Boost instances for now.
+        // TODO: Implement parameters.
+        $this->codeShift->shift(
+            new FunctionHookShiftSpec(
+                'clearstatcache',
+                fn () => function (): void {
+                    foreach ($this->boosts as $boost) {
+                        $boost->invalidateCaches();
+                    }
+                }
+            ),
+            $fileFilter
+        );
+
+        $this->codeShift->shift(
+            new FunctionHookShiftSpec(
+                'opcache_invalidate',
+                fn (callable $originalInvalidate) =>
+                    static function (string $filename, bool $force = false) use ($originalInvalidate): bool {
+                        if (ini_get('opcache.enable') === false) {
+                            return false;
+                        }
+
+                        // Work around an issue where OPcache refuses to invalidate files
+                        // served from the `file://` scheme where they do not map to a real path.
+                        $validateTimestamps = ini_set('opcache.validate_timestamps', true);
+                        $revalidateFrequency = ini_set('opcache.revalidate_freq', 0);
+                        $fileUpdateProtection = ini_set('opcache.file_update_protection', 200000);
+                        $originalInvalidate($filename, $force);
+                        // Due to the `file_update_protection` setting assigned above,
+                        // this will not actually cause a recompile of the current contents.
+                        opcache_compile_file($filename);
+                        ini_set('opcache.file_update_protection', $fileUpdateProtection);
+                        ini_set('opcache.validate_timestamps', $validateTimestamps);
+                        ini_set('opcache.revalidate_freq', $revalidateFrequency);
+
+                        return true;
+                    }
+            ),
+            $fileFilter
+        );
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function removeBoost(BoostInterface $boost): void
+    {
+        $this->boosts->detach($boost);
+
+        if (count($this->boosts) === 0) {
+            $this->codeShift->uninstall();
+        }
     }
 
     /**
@@ -35,6 +129,10 @@ class Library implements LibraryInterface
      */
     public function uninstall(): void
     {
-        $this->boost->uninstall();
+        foreach ($this->boosts as $boost) {
+            $boost->uninstall();
+        }
+
+        $this->boosts = new SplObjectStorage();
     }
 }

--- a/src/Library/Library.php
+++ b/src/Library/Library.php
@@ -20,6 +20,8 @@ use Asmblah\PhpCodeShift\Shifter\Shift\Shift\FunctionHook\FunctionHookShiftSpec;
 use Nytris\Boost\BoostInterface;
 use Nytris\Boost\Environment\Environment;
 use Nytris\Boost\Environment\EnvironmentInterface;
+use Nytris\Boost\FsCache\Canonicaliser;
+use Nytris\Boost\FsCache\CanonicaliserInterface;
 use SplObjectStorage;
 
 /**
@@ -35,11 +37,15 @@ class Library implements LibraryInterface
      * @var SplObjectStorage<BoostInterface, void>
      */
     private SplObjectStorage $boosts;
+    private readonly CanonicaliserInterface $canonicaliser;
 
     public function __construct(
         private readonly EnvironmentInterface $environment = new Environment(),
+        ?CanonicaliserInterface $canonicaliser = null,
         private readonly CodeShiftInterface $codeShift = new CodeShift()
     ) {
+        $this->canonicaliser = $canonicaliser ?? new Canonicaliser($environment);
+
         $this->boosts = new SplObjectStorage();
     }
 
@@ -53,6 +59,14 @@ class Library implements LibraryInterface
         if (count($this->boosts) === 1) {
             $this->codeShift->install();
         }
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function getCanonicaliser(): CanonicaliserInterface
+    {
+        return $this->canonicaliser;
     }
 
     /**

--- a/src/Library/LibraryInterface.php
+++ b/src/Library/LibraryInterface.php
@@ -17,12 +17,16 @@ use Asmblah\PhpCodeShift\Shifter\Filter\FileFilterInterface;
 use Nytris\Boost\BoostInterface;
 use Nytris\Boost\Environment\EnvironmentInterface;
 use Nytris\Boost\FsCache\CanonicaliserInterface;
+use Nytris\Boost\FsCache\Realpath\RealpathCacheInterface;
+use Nytris\Boost\FsCache\Stat\StatCacheInterface;
 
 /**
  * Interface LibraryInterface.
  *
  * Encapsulates an installation of the library.
  *
+ * @phpstan-import-type MultipleStatCacheStorage from StatCacheInterface
+ * @phpstan-import-type RealpathCacheStorage from RealpathCacheInterface
  * @author Dan Phillimore <dan@ovms.co>
  */
 interface LibraryInterface
@@ -41,6 +45,20 @@ interface LibraryInterface
      * Fetches the Environment.
      */
     public function getEnvironment(): EnvironmentInterface;
+
+    /**
+     * Fetches the in-memory realpath entry cache across all registered Boost instances.
+     *
+     * @return RealpathCacheStorage
+     */
+    public function getInMemoryRealpathEntryCache(): array;
+
+    /**
+     * Fetches the in-memory stat entry cache across all registered Boost instances.
+     *
+     * @return MultipleStatCacheStorage
+     */
+    public function getInMemoryStatEntryCache(): array;
 
     /**
      * Hooks built-in functions to make them compatible with Nytris Boost.

--- a/src/Library/LibraryInterface.php
+++ b/src/Library/LibraryInterface.php
@@ -13,15 +13,39 @@ declare(strict_types=1);
 
 namespace Nytris\Boost\Library;
 
+use Asmblah\PhpCodeShift\Shifter\Filter\FileFilterInterface;
+use Nytris\Boost\BoostInterface;
+use Nytris\Boost\Environment\EnvironmentInterface;
+
 /**
  * Interface LibraryInterface.
  *
- * Encapsulates an installation of the library as a Nytris package.
+ * Encapsulates an installation of the library.
  *
  * @author Dan Phillimore <dan@ovms.co>
  */
 interface LibraryInterface
 {
+    /**
+     * Adds an instance of Boost to the library installation.
+     */
+    public function addBoost(BoostInterface $boost): void;
+
+    /**
+     * Fetches the Environment.
+     */
+    public function getEnvironment(): EnvironmentInterface;
+
+    /**
+     * Hooks built-in functions to make them compatible with Nytris Boost.
+     */
+    public function hookBuiltinFunctions(FileFilterInterface $fileFilter): void;
+
+    /**
+     * Removes an instance of Boost from the library installation.
+     */
+    public function removeBoost(BoostInterface $boost): void;
+
     /**
      * Uninstalls this installation of the library.
      */

--- a/src/Library/LibraryInterface.php
+++ b/src/Library/LibraryInterface.php
@@ -16,6 +16,7 @@ namespace Nytris\Boost\Library;
 use Asmblah\PhpCodeShift\Shifter\Filter\FileFilterInterface;
 use Nytris\Boost\BoostInterface;
 use Nytris\Boost\Environment\EnvironmentInterface;
+use Nytris\Boost\FsCache\CanonicaliserInterface;
 
 /**
  * Interface LibraryInterface.
@@ -30,6 +31,11 @@ interface LibraryInterface
      * Adds an instance of Boost to the library installation.
      */
     public function addBoost(BoostInterface $boost): void;
+
+    /**
+     * Fetches the Canonicaliser.
+     */
+    public function getCanonicaliser(): CanonicaliserInterface;
 
     /**
      * Fetches the Environment.

--- a/tests/Functional/ContentsCachingTest.php
+++ b/tests/Functional/ContentsCachingTest.php
@@ -1,0 +1,250 @@
+<?php
+
+/*
+ * Nytris Boost.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\Tests\Functional;
+
+use Asmblah\PhpCodeShift\Shifter\Filter\FileFilter;
+use Mockery\MockInterface;
+use Nytris\Boost\Boost;
+use Nytris\Boost\FsCache\Contents\CachedFileInterface;
+use Nytris\Boost\FsCache\Contents\ContentsCacheInterface;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+/**
+ * Class ContentsCachingTest.
+ *
+ * Tests the file contents caching behaviour of the filesystem cache.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class ContentsCachingTest extends AbstractFunctionalTestCase
+{
+    private Boost $boost;
+    private MockInterface&CachedFileInterface $cachedPhpFileForIncludeRead;
+    private MockInterface&CachedFileInterface $cachedPhpFileForPlainRead;
+    private MockInterface&CachedFileInterface $cachedTextFile;
+    private MockInterface&ContentsCacheInterface $contentsCache;
+    private MockInterface&CacheItemInterface $realpathCacheItem;
+    private MockInterface&CacheItemPoolInterface $realpathCachePool;
+    private MockInterface&CacheItemInterface $statCacheItemForIncludes;
+    private MockInterface&CacheItemInterface $statCacheItemForNonIncludes;
+    private MockInterface&CacheItemPoolInterface $statCachePool;
+    private string $varPath;
+
+    public function setUp(): void
+    {
+        $this->cachedTextFile = mock(CachedFileInterface::class, [
+            'getContents' => 'my file contents',
+            'isCached' => true,
+        ]);
+        $this->cachedPhpFileForPlainRead = mock(CachedFileInterface::class, [
+            'getContents' => '<?php return "my result from original code";',
+            'isCached' => true,
+        ]);
+        $this->cachedPhpFileForIncludeRead = mock(CachedFileInterface::class, [
+            'getContents' => '<?php return "my result from shifted code";',
+            'isCached' => true,
+        ]);
+        $this->contentsCache = mock(ContentsCacheInterface::class);
+        $this->realpathCachePool = mock(CacheItemPoolInterface::class, [
+            'saveDeferred' => null,
+        ]);
+        $this->statCachePool = mock(CacheItemPoolInterface::class, [
+            'saveDeferred' => null,
+        ]);
+        $this->realpathCacheItem = mock(CacheItemInterface::class, [
+            'get' => [
+                '/my/cached/file.txt' => ['realpath' => '/my/cached/file.txt'],
+                '/my/cached/module.php' => ['realpath' => '/my/cached/module.php'],
+            ],
+            'isHit' => true,
+            'set' => null,
+        ]);
+        $this->statCacheItemForIncludes = mock(CacheItemInterface::class, [
+            'get' => [],
+            'isHit' => true,
+            'set' => null,
+        ]);
+        $this->statCacheItemForNonIncludes = mock(CacheItemInterface::class, [
+            'get' => [
+                '/my/cached/file.txt' => [
+                    'mode' => 0644,
+                    'uid' => 123,
+                    'gid' => 456,
+                    'size' => strlen($this->cachedTextFile->getContents()),
+                    'atime' => 1725558253,
+                    'mtime' => 1725558253,
+                    'ctime' => 1725558253,
+                ],
+                '/my/cached/module.php' => [
+                    'mode' => 0654,
+                    'uid' => 321,
+                    'gid' => 654,
+                    'size' => strlen($this->cachedPhpFileForPlainRead->getContents()),
+                    'atime' => 1725558258,
+                    'mtime' => 1725558258,
+                    'ctime' => 1725558258,
+                ],
+            ],
+            'isHit' => true,
+            'set' => null,
+        ]);
+
+        $this->varPath = dirname(__DIR__, 2) . '/var/test';
+        @mkdir($this->varPath, recursive: true);
+
+        $this->boost = new Boost(
+            realpathCachePool: $this->realpathCachePool,
+            statCachePool: $this->statCachePool,
+            realpathCacheKey: '__my_realpath_cache',
+            statCacheKey: '__my_stat_cache',
+            contentsCache: $this->contentsCache,
+            // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
+            pathFilter: new FileFilter('/my/**')
+        );
+
+        $this->realpathCachePool->allows()
+            ->getItem('__my_realpath_cache')
+            ->andReturn($this->realpathCacheItem)
+            ->byDefault();
+        $this->statCachePool->allows()
+            ->getItem('__my_stat_cache_includes')
+            ->andReturn($this->statCacheItemForIncludes)
+            ->byDefault();
+        $this->statCachePool->allows()
+            ->getItem('__my_stat_cache_plain')
+            ->andReturn($this->statCacheItemForNonIncludes)
+            ->byDefault();
+
+        $this->contentsCache->allows()
+            ->getItemForPath('/my/cached/file.txt', false)
+            ->andReturn($this->cachedTextFile)
+            ->byDefault();
+        $this->contentsCache->allows()
+            ->getItemForPath('/my/cached/module.php', true)
+            ->andReturn($this->cachedPhpFileForIncludeRead)
+            ->byDefault();
+        $this->contentsCache->allows()
+            ->getItemForPath('/my/cached/module.php', false)
+            ->andReturn($this->cachedPhpFileForPlainRead)
+            ->byDefault();
+    }
+
+    public function tearDown(): void
+    {
+        $this->boost->uninstall();
+
+        $this->rimrafDescendantsOf($this->varPath);
+    }
+
+    public function testPlainReadsHitPlainContentsCacheWhenEnabled(): void
+    {
+        $this->boost->install();
+
+        static::assertSame('my file contents', file_get_contents('/my/cached/file.txt'));
+    }
+
+    public function testIncludeReadsOfPhpModulesHitIncludeContentsCacheWhenEnabled(): void
+    {
+        $path = '/my/cached/module.php';
+        $this->boost->install();
+
+        static::assertSame('my result from shifted code', include $path);
+    }
+
+    public function testPlainReadsOfPhpModulesHitPlainContentsCacheWhenEnabled(): void
+    {
+        $this->boost->install();
+
+        static::assertSame(
+            '<?php return "my result from original code";',
+            file_get_contents('/my/cached/module.php')
+        );
+    }
+
+    public function testPlainReadMissesAreCachedInPlainContentsCacheWhenEnabled(): void
+    {
+        $textFile = mock(CachedFileInterface::class, [
+            'isCached' => false,
+        ]);
+        $imaginaryPath = '/my/path/to/my_file.txt';
+        $actualPath = __DIR__ . '/Fixtures/my_actual_file.txt';
+        $this->realpathCacheItem->allows()
+            ->get()
+            ->andReturn([
+                $imaginaryPath => ['realpath' => $actualPath],
+            ]);
+        $this->boost->install();
+
+        $this->contentsCache->expects()
+            ->getItemForPath($actualPath, false)
+            ->once()
+            ->andReturn($textFile);
+        $textFile->expects()
+            ->setContents("Hello from my file!\n")
+            ->once();
+
+        static::assertSame("Hello from my file!\n", file_get_contents($imaginaryPath));
+    }
+
+    public function testIncludeReadMissesOfPhpModulesAreCachedInIncludeContentsCacheWhenEnabled(): void
+    {
+        $phpFile = mock(CachedFileInterface::class, [
+            'isCached' => false,
+        ]);
+        $imaginaryPath = '/my/path/to/my_module.php';
+        $actualPath = __DIR__ . '/Fixtures/my_actual_file.php';
+        $this->realpathCacheItem->allows()
+            ->get()
+            ->andReturn([
+                $imaginaryPath => ['realpath' => $actualPath],
+            ]);
+        $this->boost->install();
+
+        $this->contentsCache->expects()
+            ->getItemForPath($actualPath, true)
+            ->once()
+            ->andReturn($phpFile);
+        $phpFile->expects()
+            ->setContents("<?php\n\nreturn 'my imaginary result';\n")
+            ->once();
+
+        static::assertSame('my imaginary result', include $imaginaryPath);
+    }
+
+    public function testPlainReadMissesOfPhpModulesAreCachedInPlainContentsCacheWhenEnabled(): void
+    {
+        $phpFile = mock(CachedFileInterface::class, [
+            'isCached' => false,
+        ]);
+        $imaginaryPath = '/my/path/to/my_module.php';
+        $actualPath = __DIR__ . '/Fixtures/my_actual_file.php';
+        $this->realpathCacheItem->allows()
+            ->get()
+            ->andReturn([
+                $imaginaryPath => ['realpath' => $actualPath],
+            ]);
+        $this->boost->install();
+
+        $this->contentsCache->expects()
+            ->getItemForPath($actualPath, false)
+            ->once()
+            ->andReturn($phpFile);
+        $phpFile->expects()
+            ->setContents("<?php\n\nreturn 'my imaginary result';\n")
+            ->once();
+
+        static::assertSame("<?php\n\nreturn 'my imaginary result';\n", file_get_contents($imaginaryPath));
+    }
+}

--- a/tests/Functional/ContentsCachingTest.php
+++ b/tests/Functional/ContentsCachingTest.php
@@ -14,6 +14,7 @@ declare(strict_types=1);
 namespace Nytris\Boost\Tests\Functional;
 
 use Asmblah\PhpCodeShift\Shifter\Filter\FileFilter;
+use Asmblah\PhpCodeShift\Shifter\Filter\MultipleFilter;
 use Mockery\MockInterface;
 use Nytris\Boost\Boost;
 use Nytris\Boost\FsCache\Contents\CachedFileInterface;
@@ -111,7 +112,10 @@ class ContentsCachingTest extends AbstractFunctionalTestCase
             statCacheKey: '__my_stat_cache',
             contentsCache: $this->contentsCache,
             // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
-            pathFilter: new FileFilter('/my/**')
+            pathFilter: new MultipleFilter([
+                new FileFilter('/my/**'),
+                new FileFilter(__DIR__ . '/Fixtures/**'),
+            ])
         );
 
         $this->realpathCachePool->allows()
@@ -203,7 +207,7 @@ class ContentsCachingTest extends AbstractFunctionalTestCase
         $phpFile = mock(CachedFileInterface::class, [
             'isCached' => false,
         ]);
-        $imaginaryPath = '/my/path/to/my_module.php';
+        $imaginaryPath = '/my/imaginary/path/to/my_module.php';
         $actualPath = __DIR__ . '/Fixtures/my_actual_file.php';
         $this->realpathCacheItem->allows()
             ->get()

--- a/tests/Functional/Fixtures/HookedLogic.php
+++ b/tests/Functional/Fixtures/HookedLogic.php
@@ -1,0 +1,35 @@
+<?php
+
+/*
+ * Nytris Boost
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\Tests\Functional\Fixtures;
+
+/**
+ * Class HookedLogic.
+ *
+ * A module that may be transpiled by PHP Code Shift, to allow testing of hooked functions
+ * when enabled, such as `clearstatcache(...)`.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class HookedLogic
+{
+    public function callClearstatcache(): void
+    {
+        clearstatcache();
+    }
+
+    public function callOpcacheInvalidate(string $filename, bool $force = false): bool
+    {
+        return opcache_invalidate($filename, force: $force);
+    }
+}

--- a/tests/Functional/Fixtures/my_actual_file.txt
+++ b/tests/Functional/Fixtures/my_actual_file.txt
@@ -1,0 +1,1 @@
+Hello from my file!

--- a/tests/Functional/FsCache/FilesystemFunctions/AbstractFilesystemFunctionalTestCase.php
+++ b/tests/Functional/FsCache/FilesystemFunctions/AbstractFilesystemFunctionalTestCase.php
@@ -13,11 +13,10 @@ declare(strict_types=1);
 
 namespace Nytris\Boost\Tests\Functional\FsCache\FilesystemFunctions;
 
-use Mockery\MockInterface;
 use Nytris\Boost\Boost;
 use Nytris\Boost\Tests\Functional\AbstractFunctionalTestCase;
-use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 /**
  * Class AbstractFilesystemFunctionalTestCase.
@@ -29,61 +28,24 @@ use Psr\Cache\CacheItemPoolInterface;
 abstract class AbstractFilesystemFunctionalTestCase extends AbstractFunctionalTestCase
 {
     protected Boost $boost;
-    protected MockInterface&CacheItemInterface $realpathCacheItem;
-    protected MockInterface&CacheItemPoolInterface $realpathCachePool;
-    private MockInterface&CacheItemInterface $statCacheItemForIncludes;
-    private MockInterface&CacheItemInterface $statCacheItemForNonIncludes;
-    protected MockInterface&CacheItemPoolInterface $statCachePool;
+    protected CacheItemPoolInterface $realpathCachePool;
+    protected CacheItemPoolInterface $statCachePool;
     protected string $varPath;
 
     public function setUp(): void
     {
         parent::setUp();
 
-        $this->realpathCachePool = mock(CacheItemPoolInterface::class, [
-            'saveDeferred' => null,
-        ]);
-        $this->statCachePool = mock(CacheItemPoolInterface::class, [
-            'saveDeferred' => null,
-        ]);
-        $this->realpathCacheItem = mock(CacheItemInterface::class, [
-            'get' => [],
-            'isHit' => true,
-            'set' => null,
-        ]);
-        $this->statCacheItemForIncludes = mock(CacheItemInterface::class, [
-            'get' => [],
-            'isHit' => true,
-            'set' => null,
-        ]);
-        $this->statCacheItemForNonIncludes = mock(CacheItemInterface::class, [
-            'get' => [],
-            'isHit' => true,
-            'set' => null,
-        ]);
+        $this->realpathCachePool = new ArrayAdapter();
+        $this->statCachePool = new ArrayAdapter();
 
         $this->varPath = dirname(__DIR__, 4) . '/var/test';
         @mkdir($this->varPath, recursive: true);
 
         $this->boost = new Boost(
             realpathCachePool: $this->realpathCachePool,
-            statCachePool: $this->statCachePool,
-            realpathCacheKey: '__my_realpath_cache',
-            statCacheKey: '__my_stat_cache'
+            statCachePool: $this->statCachePool
         );
-
-        $this->realpathCachePool->allows()
-            ->getItem('__my_realpath_cache')
-            ->andReturn($this->realpathCacheItem)
-            ->byDefault();
-        $this->statCachePool->allows()
-            ->getItem('__my_stat_cache_includes')
-            ->andReturn($this->statCacheItemForIncludes)
-            ->byDefault();
-        $this->statCachePool->allows()
-            ->getItem('__my_stat_cache_plain')
-            ->andReturn($this->statCacheItemForNonIncludes)
-            ->byDefault();
     }
 
     public function tearDown(): void

--- a/tests/Functional/FsCache/FilesystemFunctions/ClearstatcacheTest.php
+++ b/tests/Functional/FsCache/FilesystemFunctions/ClearstatcacheTest.php
@@ -1,0 +1,43 @@
+<?php
+
+/*
+ * Nytris Boost
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\Tests\Functional\FsCache\FilesystemFunctions;
+
+use Nytris\Boost\Tests\Functional\Fixtures\HookedLogic;
+
+/**
+ * Class ClearstatcacheTest.
+ *
+ * Tests the behaviour of the clearstatcache(...) built-in function with Nytris Boost.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class ClearstatcacheTest extends AbstractFilesystemFunctionalTestCase
+{
+    public function testClearsBoostStatCache(): void
+    {
+        $path = $this->varPath . '/my-file';
+        file_put_contents($path, 'my contents');
+        $this->boost->install();
+
+        $stat = stat($path);
+        static::assertSame(11, $stat['size']);
+        static::assertNull(shell_exec('echo " [and extra]" >> ' . escapeshellarg($path)));
+        $stat = stat($path);
+        static::assertSame(11, $stat['size'], 'Cached stat with old length should be returned');
+        // See notes in HookedLogic for why `clearstatcache(...)` cannot be called directly here.
+        (new HookedLogic())->callClearstatcache();
+        $stat = stat($path);
+        static::assertSame(24, $stat['size'], 'New stat with new length should be returned');
+    }
+}

--- a/tests/Functional/OpcacheTest.php
+++ b/tests/Functional/OpcacheTest.php
@@ -1,0 +1,194 @@
+<?php
+
+/*
+ * Nytris Boost.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\Tests\Functional;
+
+use Asmblah\PhpCodeShift\Shifter\Filter\FileFilter;
+use Asmblah\PhpCodeShift\Shifter\Filter\MultipleFilter;
+use Mockery\MockInterface;
+use Nytris\Boost\Boost;
+use Nytris\Boost\FsCache\Contents\CachedFileInterface;
+use Nytris\Boost\FsCache\Contents\ContentsCacheInterface;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+/**
+ * Class OpcacheTest.
+ *
+ * Tests the filesystem caching behaviour in conjunction with OPcache.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class OpcacheTest extends AbstractFunctionalTestCase
+{
+    private Boost $boost;
+    private MockInterface&CachedFileInterface $cachedActualPhpFileForIncludeRead;
+    private MockInterface&CachedFileInterface $cachedActualPhpFileForPlainRead;
+    private MockInterface&CachedFileInterface $cachedEmulatedPhpFileForIncludeRead;
+    private MockInterface&CachedFileInterface $cachedEmulatedPhpFileForPlainRead;
+    private MockInterface&CachedFileInterface $cachedTextFile;
+    private MockInterface&ContentsCacheInterface $contentsCache;
+    private MockInterface&CacheItemInterface $realpathCacheItem;
+    private MockInterface&CacheItemPoolInterface $realpathCachePool;
+    private MockInterface&CacheItemInterface $statCacheItemForIncludes;
+    private MockInterface&CacheItemInterface $statCacheItemForNonIncludes;
+    private MockInterface&CacheItemPoolInterface $statCachePool;
+    private string $varPath;
+
+    public function setUp(): void
+    {
+        if (
+            !extension_loaded('Zend OPcache') ||
+            !ini_get('opcache.enable') ||
+            !ini_get('opcache.enable_cli')
+        ) {
+            $this->markTestSkipped('Zend OPcache is not installed.');
+        }
+
+        $this->cachedTextFile = mock(CachedFileInterface::class, [
+            'getContents' => 'my file contents',
+            'isCached' => true,
+        ]);
+        $this->cachedActualPhpFileForPlainRead = mock(CachedFileInterface::class, [
+            'getContents' => '<?php return "my result from original code";',
+            'isCached' => true,
+        ]);
+        $this->cachedActualPhpFileForIncludeRead = mock(CachedFileInterface::class, [
+            'getContents' => '<?php return "my result from shifted code";',
+            'isCached' => true,
+        ]);
+        $this->cachedEmulatedPhpFileForPlainRead = mock(CachedFileInterface::class, [
+            'getContents' => '<?php return "my result from emulated original code";',
+            'isCached' => true,
+        ]);
+        $this->cachedEmulatedPhpFileForIncludeRead = mock(CachedFileInterface::class, [
+            'getContents' => '<?php return "my result from shifted emulated code";',
+            'isCached' => true,
+        ]);
+        $this->contentsCache = mock(ContentsCacheInterface::class);
+        $this->realpathCachePool = mock(CacheItemPoolInterface::class, [
+            'saveDeferred' => null,
+        ]);
+        $this->statCachePool = mock(CacheItemPoolInterface::class, [
+            'saveDeferred' => null,
+        ]);
+        $this->realpathCacheItem = mock(CacheItemInterface::class, [
+            'get' => [
+                '/my/cached/file.txt' => ['realpath' => '/my/cached/file.txt'],
+                '/my/emulated/cached/module.php' => ['realpath' => '/my/emulated/cached/module.php'],
+                __DIR__ . '/Fixtures/my_actual_file.php' => [
+                    'realpath' => __DIR__ . '/Fixtures/my_actual_file.php'
+                ],
+            ],
+            'isHit' => true,
+            'set' => null,
+        ]);
+        $this->statCacheItemForIncludes = mock(CacheItemInterface::class, [
+            'get' => [],
+            'isHit' => true,
+            'set' => null,
+        ]);
+        $this->statCacheItemForNonIncludes = mock(CacheItemInterface::class, [
+            'get' => [
+                '/my/emulated/cached/module.php' => [
+                    'mode' => 0654,
+                    'uid' => 321,
+                    'gid' => 654,
+                    'size' => strlen($this->cachedEmulatedPhpFileForPlainRead->getContents()),
+                    'atime' => 1725558258,
+                    'mtime' => 1725558258,
+                    'ctime' => 1725558258,
+                ],
+            ],
+            'isHit' => true,
+            'set' => null,
+        ]);
+
+        $this->varPath = dirname(__DIR__, 2) . '/var/test';
+        @mkdir($this->varPath, recursive: true);
+
+        $this->boost = new Boost(
+            realpathCachePool: $this->realpathCachePool,
+            statCachePool: $this->statCachePool,
+            realpathCacheKey: '__my_realpath_cache',
+            statCacheKey: '__my_stat_cache',
+            contentsCache: $this->contentsCache,
+            // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
+            pathFilter: new MultipleFilter([
+                new FileFilter('/my/**'),
+                new FileFilter(dirname(__DIR__) . '/**'),
+            ])
+        );
+
+        $this->realpathCachePool->allows()
+            ->getItem('__my_realpath_cache')
+            ->andReturn($this->realpathCacheItem)
+            ->byDefault();
+        $this->statCachePool->allows()
+            ->getItem('__my_stat_cache_includes')
+            ->andReturn($this->statCacheItemForIncludes)
+            ->byDefault();
+        $this->statCachePool->allows()
+            ->getItem('__my_stat_cache_plain')
+            ->andReturn($this->statCacheItemForNonIncludes)
+            ->byDefault();
+
+        $this->contentsCache->allows()
+            ->getItemForPath('/my/cached/file.txt', false)
+            ->andReturn($this->cachedTextFile)
+            ->byDefault();
+        $this->contentsCache->allows()
+            ->getItemForPath(__DIR__ . '/Fixtures/my_actual_file.php', true)
+            ->andReturn($this->cachedActualPhpFileForIncludeRead)
+            ->byDefault();
+        $this->contentsCache->allows()
+            ->getItemForPath(__DIR__ . '/Fixtures/my_actual_file.php', false)
+            ->andReturn($this->cachedActualPhpFileForPlainRead)
+            ->byDefault();
+        $this->contentsCache->allows()
+            ->getItemForPath('/my/emulated/cached/module.php', true)
+            ->andReturn($this->cachedEmulatedPhpFileForIncludeRead)
+            ->byDefault();
+        $this->contentsCache->allows()
+            ->getItemForPath('/my/emulated/cached/module.php', false)
+            ->andReturn($this->cachedEmulatedPhpFileForPlainRead)
+            ->byDefault();
+    }
+
+    public function tearDown(): void
+    {
+        $this->boost->uninstall();
+
+        $this->rimrafDescendantsOf($this->varPath);
+    }
+
+    public function testOpcacheUsesIncludeContentsCacheForAnActualFileWhenEnabled(): void
+    {
+        $path = __DIR__ . '/Fixtures/my_actual_file.php';
+        $this->boost->install();
+
+        static::assertTrue(opcache_compile_file($path));
+        static::assertSame('my result from shifted code', include $path);
+        static::assertTrue(opcache_is_script_cached($path));
+    }
+
+    public function testOpcacheUsesIncludeContentsCacheForAnEmulatedFileWhenEnabled(): void
+    {
+        $path = '/my/emulated/cached/module.php';
+        $this->boost->install();
+
+        static::assertTrue(opcache_compile_file($path));
+        static::assertSame('my result from shifted emulated code', include $path);
+        static::assertTrue(opcache_is_script_cached($path));
+    }
+}

--- a/tests/Functional/StandaloneTest.php
+++ b/tests/Functional/StandaloneTest.php
@@ -14,10 +14,9 @@ declare(strict_types=1);
 namespace Nytris\Boost\Tests\Functional;
 
 use Asmblah\PhpCodeShift\Shifter\Stream\Native\StreamWrapper;
-use Mockery\MockInterface;
 use Nytris\Boost\Boost;
-use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 /**
  * Class StandaloneTest.
@@ -30,48 +29,13 @@ use Psr\Cache\CacheItemPoolInterface;
 class StandaloneTest extends AbstractFunctionalTestCase
 {
     private ?Boost $boost = null;
-    private MockInterface&CacheItemInterface $realpathCacheItem;
-    private MockInterface&CacheItemPoolInterface $realpathCachePool;
-    private MockInterface&CacheItemInterface $statCacheItemForIncludes;
-    private MockInterface&CacheItemInterface $statCacheItemForNonIncludes;
-    private MockInterface&CacheItemPoolInterface $statCachePool;
+    private CacheItemPoolInterface $realpathCachePool;
+    private CacheItemPoolInterface $statCachePool;
 
     public function setUp(): void
     {
-        $this->realpathCachePool = mock(CacheItemPoolInterface::class, [
-            'saveDeferred' => null,
-        ]);
-        $this->statCachePool = mock(CacheItemPoolInterface::class, [
-            'saveDeferred' => null,
-        ]);
-        $this->realpathCacheItem = mock(CacheItemInterface::class, [
-            'get' => [],
-            'isHit' => true,
-            'set' => null,
-        ]);
-        $this->statCacheItemForIncludes = mock(CacheItemInterface::class, [
-            'get' => [],
-            'isHit' => true,
-            'set' => null,
-        ]);
-        $this->statCacheItemForNonIncludes = mock(CacheItemInterface::class, [
-            'get' => [],
-            'isHit' => true,
-            'set' => null,
-        ]);
-
-        $this->realpathCachePool->allows()
-            ->getItem('__my_realpath_cache')
-            ->andReturn($this->realpathCacheItem)
-            ->byDefault();
-        $this->statCachePool->allows()
-            ->getItem('__my_stat_cache_includes')
-            ->andReturn($this->statCacheItemForIncludes)
-            ->byDefault();
-        $this->statCachePool->allows()
-            ->getItem('__my_stat_cache_plain')
-            ->andReturn($this->statCacheItemForNonIncludes)
-            ->byDefault();
+        $this->realpathCachePool = new ArrayAdapter();
+        $this->statCachePool = new ArrayAdapter();
     }
 
     public function tearDown(): void
@@ -83,9 +47,7 @@ class StandaloneTest extends AbstractFunctionalTestCase
     {
         $this->boost = new Boost(
             realpathCachePool: $this->realpathCachePool,
-            statCachePool: $this->statCachePool,
-            realpathCacheKey: '__my_realpath_cache',
-            statCacheKey: '__my_stat_cache'
+            statCachePool: $this->statCachePool
         );
 
         $stream = fopen(__FILE__, 'rb');
@@ -99,9 +61,7 @@ class StandaloneTest extends AbstractFunctionalTestCase
         $path = __FILE__;
         $this->boost = new Boost(
             realpathCachePool: $this->realpathCachePool,
-            statCachePool: $this->statCachePool,
-            realpathCacheKey: '__my_realpath_cache',
-            statCacheKey: '__my_stat_cache'
+            statCachePool: $this->statCachePool
         );
 
         $this->boost->install();

--- a/tests/Functional/StandaloneTest.php
+++ b/tests/Functional/StandaloneTest.php
@@ -1,0 +1,117 @@
+<?php
+
+/*
+ * Nytris Boost.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\Tests\Functional;
+
+use Asmblah\PhpCodeShift\Shifter\Stream\Native\StreamWrapper;
+use Mockery\MockInterface;
+use Nytris\Boost\Boost;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+/**
+ * Class StandaloneTest.
+ *
+ * Tests Nytris Boost when used standalone, just via an instance of Boost,
+ * rather than as a Nytris platform package.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class StandaloneTest extends AbstractFunctionalTestCase
+{
+    private ?Boost $boost = null;
+    private MockInterface&CacheItemInterface $realpathCacheItem;
+    private MockInterface&CacheItemPoolInterface $realpathCachePool;
+    private MockInterface&CacheItemInterface $statCacheItemForIncludes;
+    private MockInterface&CacheItemInterface $statCacheItemForNonIncludes;
+    private MockInterface&CacheItemPoolInterface $statCachePool;
+
+    public function setUp(): void
+    {
+        $this->realpathCachePool = mock(CacheItemPoolInterface::class, [
+            'saveDeferred' => null,
+        ]);
+        $this->statCachePool = mock(CacheItemPoolInterface::class, [
+            'saveDeferred' => null,
+        ]);
+        $this->realpathCacheItem = mock(CacheItemInterface::class, [
+            'get' => [],
+            'isHit' => true,
+            'set' => null,
+        ]);
+        $this->statCacheItemForIncludes = mock(CacheItemInterface::class, [
+            'get' => [],
+            'isHit' => true,
+            'set' => null,
+        ]);
+        $this->statCacheItemForNonIncludes = mock(CacheItemInterface::class, [
+            'get' => [],
+            'isHit' => true,
+            'set' => null,
+        ]);
+
+        $this->realpathCachePool->allows()
+            ->getItem('__my_realpath_cache')
+            ->andReturn($this->realpathCacheItem)
+            ->byDefault();
+        $this->statCachePool->allows()
+            ->getItem('__my_stat_cache_includes')
+            ->andReturn($this->statCacheItemForIncludes)
+            ->byDefault();
+        $this->statCachePool->allows()
+            ->getItem('__my_stat_cache_plain')
+            ->andReturn($this->statCacheItemForNonIncludes)
+            ->byDefault();
+    }
+
+    public function tearDown(): void
+    {
+        $this->boost?->uninstall();
+    }
+
+    public function testStreamWrapperIsNotInstalledWhenBoostInstantiatedButNotInstalled(): void
+    {
+        $this->boost = new Boost(
+            realpathCachePool: $this->realpathCachePool,
+            statCachePool: $this->statCachePool,
+            realpathCacheKey: '__my_realpath_cache',
+            statCacheKey: '__my_stat_cache'
+        );
+
+        $stream = fopen(__FILE__, 'rb');
+        $metaData = stream_get_meta_data($stream);
+
+        static::assertSame('plainfile', $metaData['wrapper_type']);
+    }
+
+    public function testStreamWrapperIsInstalledWhenBoostIsInstalled(): void
+    {
+        $path = __FILE__;
+        $this->boost = new Boost(
+            realpathCachePool: $this->realpathCachePool,
+            statCachePool: $this->statCachePool,
+            realpathCacheKey: '__my_realpath_cache',
+            statCacheKey: '__my_stat_cache'
+        );
+
+        $this->boost->install();
+        $stream = fopen($path, 'rb');
+        $metaData = stream_get_meta_data($stream);
+
+        static::assertSame('user-space', $metaData['wrapper_type']);
+        /** @var StreamWrapper $streamWrapper */
+        $streamWrapper = $metaData['wrapper_data'];
+        static::assertInstanceOf(StreamWrapper::class, $streamWrapper);
+        static::assertSame($path, $streamWrapper->getOpenPath());
+    }
+}

--- a/tests/Functional/StatCachingTest.php
+++ b/tests/Functional/StatCachingTest.php
@@ -13,10 +13,9 @@ declare(strict_types=1);
 
 namespace Nytris\Boost\Tests\Functional;
 
-use Mockery\MockInterface;
 use Nytris\Boost\Boost;
-use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 /**
  * Class StatCachingTest.
@@ -26,59 +25,23 @@ use Psr\Cache\CacheItemPoolInterface;
 class StatCachingTest extends AbstractFunctionalTestCase
 {
     private Boost $boost;
-    private MockInterface&CacheItemInterface $realpathCacheItem;
-    private MockInterface&CacheItemPoolInterface $realpathCachePool;
-    private MockInterface&CacheItemInterface $statCacheItemForIncludes;
-    private MockInterface&CacheItemInterface $statCacheItemForNonIncludes;
-    private MockInterface&CacheItemPoolInterface $statCachePool;
+    private CacheItemPoolInterface $realpathCachePool;
+    private CacheItemPoolInterface $statCachePool;
     private string $varPath;
 
     public function setUp(): void
     {
-        $this->realpathCachePool = mock(CacheItemPoolInterface::class, [
-            'saveDeferred' => null,
-        ]);
-        $this->statCachePool = mock(CacheItemPoolInterface::class, [
-            'saveDeferred' => null,
-        ]);
-        $this->realpathCacheItem = mock(CacheItemInterface::class, [
-            'get' => [],
-            'isHit' => true,
-            'set' => null,
-        ]);
-        $this->statCacheItemForIncludes = mock(CacheItemInterface::class, [
-            'get' => [],
-            'isHit' => true,
-            'set' => null,
-        ]);
-        $this->statCacheItemForNonIncludes = mock(CacheItemInterface::class, [
-            'get' => [],
-            'isHit' => true,
-            'set' => null,
-        ]);
+        $this->realpathCachePool = new ArrayAdapter();
+        $this->statCachePool = new ArrayAdapter();
 
         $this->varPath = dirname(__DIR__, 2) . '/var/test';
         @mkdir($this->varPath, recursive: true);
 
         $this->boost = new Boost(
             realpathCachePool: $this->realpathCachePool,
-            statCachePool: $this->statCachePool,
-            realpathCacheKey: '__my_realpath_cache',
-            statCacheKey: '__my_stat_cache'
+            statCachePool: $this->statCachePool
         );
-
-        $this->realpathCachePool->allows()
-            ->getItem('__my_realpath_cache')
-            ->andReturn($this->realpathCacheItem)
-            ->byDefault();
-        $this->statCachePool->allows()
-            ->getItem('__my_stat_cache_includes')
-            ->andReturn($this->statCacheItemForIncludes)
-            ->byDefault();
-        $this->statCachePool->allows()
-            ->getItem('__my_stat_cache_plain')
-            ->andReturn($this->statCacheItemForNonIncludes)
-            ->byDefault();
+        $this->canonicaliser = $this->boost->getLibrary()->getCanonicaliser();
     }
 
     public function tearDown(): void
@@ -93,45 +56,16 @@ class StatCachingTest extends AbstractFunctionalTestCase
         $actualPath = __DIR__ . '/Fixtures/my_actual_file.php';
         $imaginaryPath = __DIR__ . '/Fixtures/my_imaginary_file.php';
         $actualPathStat = stat($actualPath);
-        $this->realpathCacheItem->allows()
-            ->get()
-            ->andReturn([
-                $imaginaryPath => [
-                    // Unlike the test above, the realpath cache has the imaginary path as the target.
-                    'realpath' => $imaginaryPath,
-                ]
-            ]);
-        $this->statCacheItemForNonIncludes->allows()
-            ->get()
-            ->andReturn([
-                $imaginaryPath => $actualPathStat,
-            ]);
+        $this->setRealpathPsrCacheItem($this->realpathCachePool, $imaginaryPath, [
+            // Unlike the test above, the realpath cache has the imaginary path as the target.
+            'realpath' => $imaginaryPath,
+        ]);
+        $this->setStatPsrCacheItem($this->statCachePool, $imaginaryPath, isInclude: false, value: $actualPathStat);
         $this->boost->install();
 
         static::assertEquals(stat($imaginaryPath), $actualPathStat);
         static::assertTrue(file_exists($imaginaryPath));
         static::assertTrue(is_file($imaginaryPath));
         static::assertFalse(is_dir($imaginaryPath));
-    }
-
-    public function testStatCacheIsPersistedOnDestructionWhenChangesMade(): void
-    {
-        $this->statCachePool->expects()
-            ->saveDeferred($this->statCacheItemForNonIncludes)
-            ->once();
-
-        $this->boost->install();
-        file_put_contents($this->varPath . '/my_file.txt', 'my contents');
-        $this->boost->uninstall();
-    }
-
-    public function testStatCacheIsNotPersistedOnDestructionWhenNoChangesMade(): void
-    {
-        $this->statCachePool->expects()
-            ->saveDeferred($this->statCacheItemForNonIncludes)
-            ->never();
-
-        $this->boost->install();
-        $this->boost->uninstall();
     }
 }

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/ChgrpTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/ChgrpTest.php
@@ -57,8 +57,6 @@ class ChgrpTest extends AbstractFunctionalTestCase
             library: new Library($this->environment),
             realpathCachePool: $this->realpathCachePool,
             statCachePool: $this->statCachePool,
-            realpathCacheKey: '__my_realpath_cache',
-            statCacheKey: '__my_stat_cache',
             hookBuiltinFunctions: false,
             contentsCache: $this->contentsCache,
             // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/ChgrpTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/ChgrpTest.php
@@ -1,0 +1,141 @@
+<?php
+
+/*
+ * Nytris Boost.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\Tests\Functional\VirtualFilesystemMode\FilesystemFunctions;
+
+use Asmblah\PhpCodeShift\Shifter\Filter\FileFilter;
+use Mockery\MockInterface;
+use Nytris\Boost\Boost;
+use Nytris\Boost\Environment\EnvironmentInterface;
+use Nytris\Boost\FsCache\Contents\ContentsCacheInterface;
+use Nytris\Boost\FsCache\Contents\SinglePoolContentsCache;
+use Nytris\Boost\Library\Library;
+use Nytris\Boost\Tests\Functional\AbstractFunctionalTestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * Class ChgrpTest.
+ *
+ * Tests the behaviour of the `chgrp(...)` built-in function
+ * with Nytris Boost in virtual filesystem mode.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class ChgrpTest extends AbstractFunctionalTestCase
+{
+    private Boost $boost;
+    private ContentsCacheInterface $contentsCache;
+    private MockInterface&EnvironmentInterface $environment;
+    private CacheItemPoolInterface $realpathCachePool;
+    private CacheItemPoolInterface $statCachePool;
+
+    public function setUp(): void
+    {
+        $this->contentsCache = new SinglePoolContentsCache(new ArrayAdapter());
+        $this->environment = mock(EnvironmentInterface::class, [
+            'getCwd' => '/my/cwd',
+            'getStartTime' => 1726739286,
+        ]);
+        $this->realpathCachePool = new ArrayAdapter();
+        $this->statCachePool = new ArrayAdapter();
+
+        // Load Mockery internals for the stub as there is a catch-22 with the path filtering.
+        $this->environment->getCwd();
+
+        $this->boost = new Boost(
+            library: new Library($this->environment),
+            realpathCachePool: $this->realpathCachePool,
+            statCachePool: $this->statCachePool,
+            realpathCacheKey: '__my_realpath_cache',
+            statCacheKey: '__my_stat_cache',
+            hookBuiltinFunctions: false,
+            contentsCache: $this->contentsCache,
+            // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
+            pathFilter: new FileFilter('/my/**'),
+            asVirtualFilesystem: true
+        );
+    }
+
+    public function tearDown(): void
+    {
+        $this->boost->uninstall();
+    }
+
+    public function testCanChangeGroupOfAFileByGid(): void
+    {
+        $this->boost->install();
+        file_put_contents('/my/virtual/file.txt', 'my file contents');
+
+        static::assertTrue(chgrp('/my/virtual/file.txt', 123));
+        $stat = stat('/my/virtual/file.txt');
+        static::assertSame(123, $stat['gid']);
+        static::assertSame(123, $stat[5]);
+    }
+
+    public function testCanChangeGroupOfAFileByGroupName(): void
+    {
+        $this->environment->allows()
+            ->getGroupIdFromName('mygroup')
+            ->andReturn(123);
+        $this->boost->install();
+        file_put_contents('/my/virtual/file.txt', 'my file contents');
+
+        static::assertTrue(chgrp('/my/virtual/file.txt', 'mygroup'));
+        $stat = stat('/my/virtual/file.txt');
+        static::assertSame(123, $stat['gid']);
+        static::assertSame(123, $stat[5]);
+    }
+
+    public function testCanChangeGroupOfADirectoryByGid(): void
+    {
+        $this->boost->install();
+        mkdir('/my/virtual/dir', recursive: true);
+
+        static::assertTrue(chgrp('/my/virtual/dir', 456));
+        $stat = stat('/my/virtual/dir');
+        static::assertSame(456, $stat['gid']);
+        static::assertSame(456, $stat[5]);
+    }
+
+    public function testCanChangeGroupOfADirectoryByGroupName(): void
+    {
+        $this->environment->allows()
+            ->getGroupIdFromName('yourgroup')
+            ->andReturn(456);
+        $this->boost->install();
+        mkdir('/my/virtual/dir', recursive: true);
+
+        static::assertTrue(chgrp('/my/virtual/dir', 'yourgroup'));
+        $stat = stat('/my/virtual/dir');
+        static::assertSame(456, $stat['gid']);
+        static::assertSame(456, $stat[5]);
+    }
+
+    public function testReturnsFalseForNonExistentFileWhenGidGiven(): void
+    {
+        $this->boost->install();
+
+        static::assertFalse(chgrp('/my/virtual/non_existent_file.txt', 123));
+    }
+
+    public function testReturnsFalseForNonExistentFileWhenGroupNameGiven(): void
+    {
+        $this->environment->allows()
+            ->getGroupIdFromName('mygroup')
+            ->andReturn(123);
+        $this->boost->install();
+
+        static::assertFalse(chgrp('/my/virtual/non_existent_file.txt', 'mygroup'));
+    }
+}

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/ChmodTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/ChmodTest.php
@@ -45,8 +45,6 @@ class ChmodTest extends AbstractFunctionalTestCase
         $this->boost = new Boost(
             realpathCachePool: $this->realpathCachePool,
             statCachePool: $this->statCachePool,
-            realpathCacheKey: '__my_realpath_cache',
-            statCacheKey: '__my_stat_cache',
             contentsCache: $this->contentsCache,
             // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
             pathFilter: new FileFilter('/my/**'),

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/ChmodTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/ChmodTest.php
@@ -1,0 +1,90 @@
+<?php
+
+/*
+ * Nytris Boost.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\Tests\Functional\VirtualFilesystemMode\FilesystemFunctions;
+
+use Asmblah\PhpCodeShift\Shifter\Filter\FileFilter;
+use Nytris\Boost\Boost;
+use Nytris\Boost\FsCache\Contents\ContentsCacheInterface;
+use Nytris\Boost\FsCache\Contents\SinglePoolContentsCache;
+use Nytris\Boost\Tests\Functional\AbstractFunctionalTestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * Class ChmodTest.
+ *
+ * Tests the behaviour of the `chmod(...)` built-in function
+ * with Nytris Boost in virtual filesystem mode.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class ChmodTest extends AbstractFunctionalTestCase
+{
+    private Boost $boost;
+    private ContentsCacheInterface $contentsCache;
+    private CacheItemPoolInterface $realpathCachePool;
+    private CacheItemPoolInterface $statCachePool;
+
+    public function setUp(): void
+    {
+        $this->contentsCache = new SinglePoolContentsCache(new ArrayAdapter());
+        $this->realpathCachePool = new ArrayAdapter();
+        $this->statCachePool = new ArrayAdapter();
+
+        $this->boost = new Boost(
+            realpathCachePool: $this->realpathCachePool,
+            statCachePool: $this->statCachePool,
+            realpathCacheKey: '__my_realpath_cache',
+            statCacheKey: '__my_stat_cache',
+            contentsCache: $this->contentsCache,
+            // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
+            pathFilter: new FileFilter('/my/**'),
+            asVirtualFilesystem: true
+        );
+    }
+
+    public function tearDown(): void
+    {
+        $this->boost->uninstall();
+    }
+
+    public function testCanChangeAccessModeOfAFile(): void
+    {
+        $this->boost->install();
+        file_put_contents('/my/virtual/file.txt', 'my file contents');
+
+        static::assertTrue(chmod('/my/virtual/file.txt', 0754));
+        $stat = stat('/my/virtual/file.txt');
+        static::assertSame(0100754, $stat['mode']);
+        static::assertSame(0100754, $stat[2]);
+    }
+
+    public function testCanChangeAccessModeOfADirectory(): void
+    {
+        $this->boost->install();
+        mkdir('/my/virtual/dir', recursive: true);
+
+        static::assertTrue(chmod('/my/virtual/dir', 0754));
+        $stat = stat('/my/virtual/dir');
+        static::assertSame(040754, $stat['mode']);
+        static::assertSame(040754, $stat[2]);
+    }
+
+    public function testReturnsFalseForNonExistentFile(): void
+    {
+        $this->boost->install();
+
+        static::assertFalse(chmod('/my/virtual/non_existent_file.txt', 0655));
+    }
+}

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/ChownTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/ChownTest.php
@@ -1,0 +1,140 @@
+<?php
+
+/*
+ * Nytris Boost.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\Tests\Functional\VirtualFilesystemMode\FilesystemFunctions;
+
+use Asmblah\PhpCodeShift\Shifter\Filter\FileFilter;
+use Mockery\MockInterface;
+use Nytris\Boost\Boost;
+use Nytris\Boost\Environment\EnvironmentInterface;
+use Nytris\Boost\FsCache\Contents\ContentsCacheInterface;
+use Nytris\Boost\FsCache\Contents\SinglePoolContentsCache;
+use Nytris\Boost\Library\Library;
+use Nytris\Boost\Tests\Functional\AbstractFunctionalTestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * Class ChownTest.
+ *
+ * Tests the behaviour of the `chown(...)` built-in function
+ * with Nytris Boost in virtual filesystem mode.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class ChownTest extends AbstractFunctionalTestCase
+{
+    private Boost $boost;
+    private ContentsCacheInterface $contentsCache;
+    private MockInterface&EnvironmentInterface $environment;
+    private CacheItemPoolInterface $realpathCachePool;
+    private CacheItemPoolInterface $statCachePool;
+
+    public function setUp(): void
+    {
+        $this->contentsCache = new SinglePoolContentsCache(new ArrayAdapter());
+        $this->environment = mock(EnvironmentInterface::class, [
+            'getCwd' => '/my/cwd',
+            'getStartTime' => 1726739286,
+        ]);
+        $this->realpathCachePool = new ArrayAdapter();
+        $this->statCachePool = new ArrayAdapter();
+
+        // Load Mockery internals for the stub as there is a catch-22 with the path filtering.
+        $this->environment->getCwd();
+
+        $this->boost = new Boost(
+            library: new Library($this->environment),
+            realpathCachePool: $this->realpathCachePool,
+            statCachePool: $this->statCachePool,
+            realpathCacheKey: '__my_realpath_cache',
+            statCacheKey: '__my_stat_cache',
+            contentsCache: $this->contentsCache,
+            // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
+            pathFilter: new FileFilter('/my/**'),
+            asVirtualFilesystem: true
+        );
+    }
+
+    public function tearDown(): void
+    {
+        $this->boost->uninstall();
+    }
+
+    public function testCanChangeOwnerOfAFileByUid(): void
+    {
+        $this->boost->install();
+        file_put_contents('/my/virtual/file.txt', 'my file contents');
+
+        static::assertTrue(chown('/my/virtual/file.txt', 123));
+        $stat = stat('/my/virtual/file.txt');
+        static::assertSame(123, $stat['uid']);
+        static::assertSame(123, $stat[4]);
+    }
+
+    public function testCanChangeOwnerOfAFileByUsername(): void
+    {
+        $this->environment->allows()
+            ->getUserIdFromName('myuser')
+            ->andReturn(123);
+        $this->boost->install();
+        file_put_contents('/my/virtual/file.txt', 'my file contents');
+
+        static::assertTrue(chown('/my/virtual/file.txt', 'myuser'));
+        $stat = stat('/my/virtual/file.txt');
+        static::assertSame(123, $stat['uid']);
+        static::assertSame(123, $stat[4]);
+    }
+
+    public function testCanChangeOwnerOfADirectoryByUid(): void
+    {
+        $this->boost->install();
+        mkdir('/my/virtual/dir', recursive: true);
+
+        static::assertTrue(chown('/my/virtual/dir', 456));
+        $stat = stat('/my/virtual/dir');
+        static::assertSame(456, $stat['uid']);
+        static::assertSame(456, $stat[4]);
+    }
+
+    public function testCanChangeOwnerOfADirectoryByUsername(): void
+    {
+        $this->environment->allows()
+            ->getUserIdFromName('youruser')
+            ->andReturn(456);
+        $this->boost->install();
+        mkdir('/my/virtual/dir', recursive: true);
+
+        static::assertTrue(chown('/my/virtual/dir', 'youruser'));
+        $stat = stat('/my/virtual/dir');
+        static::assertSame(456, $stat['uid']);
+        static::assertSame(456, $stat[4]);
+    }
+
+    public function testReturnsFalseForNonExistentFileWhenUidGiven(): void
+    {
+        $this->boost->install();
+
+        static::assertFalse(chown('/my/virtual/non_existent_file.txt', 123));
+    }
+
+    public function testReturnsFalseForNonExistentFileWhenUsernameGiven(): void
+    {
+        $this->environment->allows()
+            ->getUserIdFromName('myuser')
+            ->andReturn(123);
+        $this->boost->install();
+
+        static::assertFalse(chown('/my/virtual/non_existent_file.txt', 'myuser'));
+    }
+}

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/ChownTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/ChownTest.php
@@ -57,8 +57,6 @@ class ChownTest extends AbstractFunctionalTestCase
             library: new Library($this->environment),
             realpathCachePool: $this->realpathCachePool,
             statCachePool: $this->statCachePool,
-            realpathCacheKey: '__my_realpath_cache',
-            statCacheKey: '__my_stat_cache',
             contentsCache: $this->contentsCache,
             // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
             pathFilter: new FileFilter('/my/**'),

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/ClearstatcacheTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/ClearstatcacheTest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * Nytris Boost.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\Tests\Functional\VirtualFilesystemMode\FilesystemFunctions;
+
+use Asmblah\PhpCodeShift\Shifter\Filter\FileFilter;
+use Nytris\Boost\Boost;
+use Nytris\Boost\FsCache\Contents\ContentsCacheInterface;
+use Nytris\Boost\FsCache\Contents\SinglePoolContentsCache;
+use Nytris\Boost\Tests\Functional\AbstractFunctionalTestCase;
+use Nytris\Boost\Tests\Functional\Fixtures\HookedLogic;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * Class ClearstatcacheTest.
+ *
+ * Tests the behaviour of the `clearstatcache(...)` built-in function
+ * with Nytris Boost in virtual filesystem mode.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class ClearstatcacheTest extends AbstractFunctionalTestCase
+{
+    private Boost $boost;
+    private ContentsCacheInterface $contentsCache;
+    private CacheItemPoolInterface $realpathCachePool;
+    private CacheItemPoolInterface $statCachePool;
+
+    public function setUp(): void
+    {
+        $this->contentsCache = new SinglePoolContentsCache(new ArrayAdapter());
+        $this->realpathCachePool = new ArrayAdapter();
+        $this->statCachePool = new ArrayAdapter();
+
+        $this->boost = new Boost(
+            realpathCachePool: $this->realpathCachePool,
+            statCachePool: $this->statCachePool,
+            realpathCacheKey: '__my_realpath_cache',
+            statCacheKey: '__my_stat_cache',
+            contentsCache: $this->contentsCache,
+            // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
+            pathFilter: new FileFilter('/my/**'),
+            asVirtualFilesystem: true
+        );
+    }
+
+    public function tearDown(): void
+    {
+        $this->boost->uninstall();
+    }
+
+    public function testDoesNotAffectVirtualFilesystem(): void
+    {
+        $this->boost->install();
+        file_put_contents('/my/virtual/file.txt', 'my file contents');
+
+        // See notes in HookedLogic for why `clearstatcache(...)` cannot be called directly here.
+        (new HookedLogic())->callClearstatcache();
+
+        // In virtual filesystem mode, the caches are the filesystem storage so should not be invalidated.
+        static::assertTrue(is_file('/my/virtual/file.txt'));
+    }
+}

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/ClearstatcacheTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/ClearstatcacheTest.php
@@ -46,8 +46,6 @@ class ClearstatcacheTest extends AbstractFunctionalTestCase
         $this->boost = new Boost(
             realpathCachePool: $this->realpathCachePool,
             statCachePool: $this->statCachePool,
-            realpathCacheKey: '__my_realpath_cache',
-            statCacheKey: '__my_stat_cache',
             contentsCache: $this->contentsCache,
             // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
             pathFilter: new FileFilter('/my/**'),

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/CopyTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/CopyTest.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * Nytris Boost.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\Tests\Functional\VirtualFilesystemMode\FilesystemFunctions;
+
+use Asmblah\PhpCodeShift\Shifter\Filter\FileFilter;
+use Nytris\Boost\Boost;
+use Nytris\Boost\FsCache\Contents\ContentsCacheInterface;
+use Nytris\Boost\FsCache\Contents\SinglePoolContentsCache;
+use Nytris\Boost\Tests\Functional\AbstractFunctionalTestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * Class CopyTest.
+ *
+ * Tests the behaviour of the `copy(...)` built-in function
+ * with Nytris Boost in virtual filesystem mode.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class CopyTest extends AbstractFunctionalTestCase
+{
+    private Boost $boost;
+    private ContentsCacheInterface $contentsCache;
+    private CacheItemPoolInterface $realpathCachePool;
+    private CacheItemPoolInterface $statCachePool;
+    private string $varPath;
+
+    public function setUp(): void
+    {
+        $this->contentsCache = new SinglePoolContentsCache(new ArrayAdapter());
+        $this->realpathCachePool = new ArrayAdapter();
+        $this->statCachePool = new ArrayAdapter();
+
+        $this->varPath = dirname(__DIR__, 4) . '/var/test';
+        @mkdir($this->varPath, recursive: true);
+
+        $this->boost = new Boost(
+            realpathCachePool: $this->realpathCachePool,
+            statCachePool: $this->statCachePool,
+            realpathCacheKey: '__my_realpath_cache',
+            statCacheKey: '__my_stat_cache',
+            contentsCache: $this->contentsCache,
+            // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
+            pathFilter: new FileFilter('/my/**'),
+            asVirtualFilesystem: true
+        );
+    }
+
+    public function tearDown(): void
+    {
+        $this->boost->uninstall();
+
+        $this->rimrafDescendantsOf($this->varPath);
+    }
+
+    public function testCanCopyAnExistingFileFromAndToVirtualFilesystem(): void
+    {
+        $sourcePath = '/my/virtual/source_file.txt';
+        $destinationPath = '/my/virtual/dest_file.txt';
+        $this->boost->install();
+        file_put_contents($sourcePath, 'my file contents');
+
+        static::assertTrue(copy($sourcePath, $destinationPath));
+        static::assertTrue(is_file($sourcePath));
+        static::assertTrue(is_file($destinationPath));
+        static::assertSame('my file contents', file_get_contents($destinationPath));
+    }
+
+    public function testCanCopyAnExistingFileFromOutsideToInsideVirtualFilesystem(): void
+    {
+        $sourcePath = $this->varPath . '/source_file.txt';
+        $destinationPath = '/my/virtual/dest_file.txt';
+        file_put_contents($sourcePath, 'my file contents');
+        $this->boost->install();
+
+        static::assertTrue(copy($sourcePath, $destinationPath));
+        static::assertTrue(is_file($sourcePath));
+        static::assertTrue(is_file($destinationPath));
+        static::assertSame('my file contents', file_get_contents($destinationPath));
+    }
+
+    public function testCanCopyAnExistingFileFromInsideToOutsideVirtualFilesystem(): void
+    {
+        $sourcePath = '/my/virtual/source_file.txt';
+        $destinationPath = $this->varPath . '/dest_file.txt';
+        $this->boost->install();
+        file_put_contents($sourcePath, 'my file contents');
+
+        static::assertTrue(copy($sourcePath, $destinationPath));
+        static::assertTrue(is_file($sourcePath));
+        static::assertTrue(is_file($destinationPath));
+        static::assertSame('my file contents', file_get_contents($destinationPath));
+    }
+
+    public function testReturnsFalseForANonExistentSourceFileInVirtualFilesystem(): void
+    {
+        $sourcePath = '/my/virtual/non_existent_source_file.txt';
+        $destinationPath = '/my/virtual/dest_file.txt';
+        $this->boost->install();
+
+        static::assertFalse(@copy($sourcePath, $destinationPath));
+        static::assertFalse(file_exists($destinationPath));
+    }
+}

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/CopyTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/CopyTest.php
@@ -49,8 +49,6 @@ class CopyTest extends AbstractFunctionalTestCase
         $this->boost = new Boost(
             realpathCachePool: $this->realpathCachePool,
             statCachePool: $this->statCachePool,
-            realpathCacheKey: '__my_realpath_cache',
-            statCacheKey: '__my_stat_cache',
             contentsCache: $this->contentsCache,
             // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
             pathFilter: new FileFilter('/my/**'),

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/FflushTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/FflushTest.php
@@ -45,8 +45,6 @@ class FflushTest extends AbstractFunctionalTestCase
         $this->boost = new Boost(
             realpathCachePool: $this->realpathCachePool,
             statCachePool: $this->statCachePool,
-            realpathCacheKey: '__my_realpath_cache',
-            statCacheKey: '__my_stat_cache',
             contentsCache: $this->contentsCache,
             // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
             pathFilter: new FileFilter('/my/**'),

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/FflushTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/FflushTest.php
@@ -1,0 +1,73 @@
+<?php
+
+/*
+ * Nytris Boost.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\Tests\Functional\VirtualFilesystemMode\FilesystemFunctions;
+
+use Asmblah\PhpCodeShift\Shifter\Filter\FileFilter;
+use Nytris\Boost\Boost;
+use Nytris\Boost\FsCache\Contents\ContentsCacheInterface;
+use Nytris\Boost\FsCache\Contents\SinglePoolContentsCache;
+use Nytris\Boost\Tests\Functional\AbstractFunctionalTestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * Class FflushTest.
+ *
+ * Tests the behaviour of the `fflush(...)` built-in function
+ * with Nytris Boost in virtual filesystem mode.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class FflushTest extends AbstractFunctionalTestCase
+{
+    private Boost $boost;
+    private ContentsCacheInterface $contentsCache;
+    private CacheItemPoolInterface $realpathCachePool;
+    private CacheItemPoolInterface $statCachePool;
+
+    public function setUp(): void
+    {
+        $this->contentsCache = new SinglePoolContentsCache(new ArrayAdapter());
+        $this->realpathCachePool = new ArrayAdapter();
+        $this->statCachePool = new ArrayAdapter();
+
+        $this->boost = new Boost(
+            realpathCachePool: $this->realpathCachePool,
+            statCachePool: $this->statCachePool,
+            realpathCacheKey: '__my_realpath_cache',
+            statCacheKey: '__my_stat_cache',
+            contentsCache: $this->contentsCache,
+            // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
+            pathFilter: new FileFilter('/my/**'),
+            asVirtualFilesystem: true
+        );
+    }
+
+    public function tearDown(): void
+    {
+        $this->boost->uninstall();
+    }
+
+    public function testWrittenDataIsFlushed(): void
+    {
+        $path = '/my/virtual/file.txt';
+        $this->boost->install();
+
+        $writeStream = fopen($path, 'wb');
+        fwrite($writeStream, 'my file contents');
+        static::assertTrue(fflush($writeStream));
+        $readStream = fopen($path, 'rb');
+        static::assertSame('my file contents', fread($readStream, 1024));
+    }
+}

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/FileExistsTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/FileExistsTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * Nytris Boost.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\Tests\Functional\VirtualFilesystemMode\FilesystemFunctions;
+
+use Asmblah\PhpCodeShift\Shifter\Filter\FileFilter;
+use Nytris\Boost\Boost;
+use Nytris\Boost\FsCache\Contents\ContentsCacheInterface;
+use Nytris\Boost\FsCache\Contents\SinglePoolContentsCache;
+use Nytris\Boost\Tests\Functional\AbstractFunctionalTestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * Class FileExistsTest.
+ *
+ * Tests the behaviour of the `file_exists(...)` built-in function
+ * with Nytris Boost in virtual filesystem mode.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class FileExistsTest extends AbstractFunctionalTestCase
+{
+    private Boost $boost;
+    private ContentsCacheInterface $contentsCache;
+    private CacheItemPoolInterface $realpathCachePool;
+    private CacheItemPoolInterface $statCachePool;
+
+    public function setUp(): void
+    {
+        $this->contentsCache = new SinglePoolContentsCache(new ArrayAdapter());
+        $this->realpathCachePool = new ArrayAdapter();
+        $this->statCachePool = new ArrayAdapter();
+
+        $this->boost = new Boost(
+            realpathCachePool: $this->realpathCachePool,
+            statCachePool: $this->statCachePool,
+            realpathCacheKey: '__my_realpath_cache',
+            statCacheKey: '__my_stat_cache',
+            contentsCache: $this->contentsCache,
+            // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
+            pathFilter: new FileFilter('/my/**'),
+            asVirtualFilesystem: true
+        );
+    }
+
+    public function tearDown(): void
+    {
+        $this->boost->uninstall();
+    }
+
+    public function testFileExistenceMayBeCorrectlyTested(): void
+    {
+        $this->boost->install();
+        file_put_contents('/my/virtual/file.txt', 'my file contents');
+
+        static::assertTrue(file_exists('/my/virtual/file.txt'));
+        static::assertFalse(file_exists('/my/virtual/non_existent_file.txt'));
+    }
+}

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/FileExistsTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/FileExistsTest.php
@@ -45,8 +45,6 @@ class FileExistsTest extends AbstractFunctionalTestCase
         $this->boost = new Boost(
             realpathCachePool: $this->realpathCachePool,
             statCachePool: $this->statCachePool,
-            realpathCacheKey: '__my_realpath_cache',
-            statCacheKey: '__my_stat_cache',
             contentsCache: $this->contentsCache,
             // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
             pathFilter: new FileFilter('/my/**'),

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/FilePutContentsTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/FilePutContentsTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * Nytris Boost.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\Tests\Functional\VirtualFilesystemMode\FilesystemFunctions;
+
+use Asmblah\PhpCodeShift\Shifter\Filter\FileFilter;
+use Nytris\Boost\Boost;
+use Nytris\Boost\FsCache\Contents\ContentsCacheInterface;
+use Nytris\Boost\FsCache\Contents\SinglePoolContentsCache;
+use Nytris\Boost\Tests\Functional\AbstractFunctionalTestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * Class FilePutContentsTest.
+ *
+ * Tests the behaviour of the `file_put_contents(...)` built-in function
+ * with Nytris Boost in virtual filesystem mode.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class FilePutContentsTest extends AbstractFunctionalTestCase
+{
+    private Boost $boost;
+    private ContentsCacheInterface $contentsCache;
+    private CacheItemPoolInterface $realpathCachePool;
+    private CacheItemPoolInterface $statCachePool;
+
+    public function setUp(): void
+    {
+        $this->contentsCache = new SinglePoolContentsCache(new ArrayAdapter());
+        $this->realpathCachePool = new ArrayAdapter();
+        $this->statCachePool = new ArrayAdapter();
+
+        $this->boost = new Boost(
+            realpathCachePool: $this->realpathCachePool,
+            statCachePool: $this->statCachePool,
+            realpathCacheKey: '__my_realpath_cache',
+            statCacheKey: '__my_stat_cache',
+            contentsCache: $this->contentsCache,
+            // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
+            pathFilter: new FileFilter('/my/**'),
+            asVirtualFilesystem: true
+        );
+    }
+
+    public function tearDown(): void
+    {
+        $this->boost->uninstall();
+    }
+
+    public function testNewFilesMayBeWrittenAndThenRead(): void
+    {
+        $this->boost->install();
+
+        file_put_contents('/my/virtual/file.txt', 'my file contents');
+
+        static::assertSame('my file contents', file_get_contents('/my/virtual/file.txt'));
+    }
+}

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/FilePutContentsTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/FilePutContentsTest.php
@@ -45,8 +45,6 @@ class FilePutContentsTest extends AbstractFunctionalTestCase
         $this->boost = new Boost(
             realpathCachePool: $this->realpathCachePool,
             statCachePool: $this->statCachePool,
-            realpathCacheKey: '__my_realpath_cache',
-            statCacheKey: '__my_stat_cache',
             contentsCache: $this->contentsCache,
             // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
             pathFilter: new FileFilter('/my/**'),

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/FilesizeTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/FilesizeTest.php
@@ -45,8 +45,6 @@ class FilesizeTest extends AbstractFunctionalTestCase
         $this->boost = new Boost(
             realpathCachePool: $this->realpathCachePool,
             statCachePool: $this->statCachePool,
-            realpathCacheKey: '__my_realpath_cache',
-            statCacheKey: '__my_stat_cache',
             contentsCache: $this->contentsCache,
             // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
             pathFilter: new FileFilter('/my/**'),

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/FilesizeTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/FilesizeTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * Nytris Boost.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\Tests\Functional\VirtualFilesystemMode\FilesystemFunctions;
+
+use Asmblah\PhpCodeShift\Shifter\Filter\FileFilter;
+use Nytris\Boost\Boost;
+use Nytris\Boost\FsCache\Contents\ContentsCacheInterface;
+use Nytris\Boost\FsCache\Contents\SinglePoolContentsCache;
+use Nytris\Boost\Tests\Functional\AbstractFunctionalTestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * Class FilesizeTest.
+ *
+ * Tests the behaviour of the `filesize(...)` built-in function
+ * with Nytris Boost in virtual filesystem mode.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class FilesizeTest extends AbstractFunctionalTestCase
+{
+    private Boost $boost;
+    private ContentsCacheInterface $contentsCache;
+    private CacheItemPoolInterface $realpathCachePool;
+    private CacheItemPoolInterface $statCachePool;
+
+    public function setUp(): void
+    {
+        $this->contentsCache = new SinglePoolContentsCache(new ArrayAdapter());
+        $this->realpathCachePool = new ArrayAdapter();
+        $this->statCachePool = new ArrayAdapter();
+
+        $this->boost = new Boost(
+            realpathCachePool: $this->realpathCachePool,
+            statCachePool: $this->statCachePool,
+            realpathCacheKey: '__my_realpath_cache',
+            statCacheKey: '__my_stat_cache',
+            contentsCache: $this->contentsCache,
+            // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
+            pathFilter: new FileFilter('/my/**'),
+            asVirtualFilesystem: true
+        );
+    }
+
+    public function tearDown(): void
+    {
+        $this->boost->uninstall();
+    }
+
+    public function testFileSizeIsReturnedCorrectly(): void
+    {
+        $this->boost->install();
+        file_put_contents('/my/virtual/file.txt', 'my file contents');
+
+        static::assertSame(16, filesize('/my/virtual/file.txt'));
+    }
+
+    public function testReturnsFalseForNonExistentFile(): void
+    {
+        $this->boost->install();
+
+        static::assertFalse(@filesize('/my/virtual/non_existent_file.txt'));
+    }
+}

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/FiletypeTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/FiletypeTest.php
@@ -45,8 +45,6 @@ class FiletypeTest extends AbstractFunctionalTestCase
         $this->boost = new Boost(
             realpathCachePool: $this->realpathCachePool,
             statCachePool: $this->statCachePool,
-            realpathCacheKey: '__my_realpath_cache',
-            statCacheKey: '__my_stat_cache',
             contentsCache: $this->contentsCache,
             // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
             pathFilter: new FileFilter('/my/**'),

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/FiletypeTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/FiletypeTest.php
@@ -1,0 +1,84 @@
+<?php
+
+/*
+ * Nytris Boost.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\Tests\Functional\VirtualFilesystemMode\FilesystemFunctions;
+
+use Asmblah\PhpCodeShift\Shifter\Filter\FileFilter;
+use Nytris\Boost\Boost;
+use Nytris\Boost\FsCache\Contents\ContentsCacheInterface;
+use Nytris\Boost\FsCache\Contents\SinglePoolContentsCache;
+use Nytris\Boost\Tests\Functional\AbstractFunctionalTestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * Class FiletypeTest.
+ *
+ * Tests the behaviour of the `filetype(...)` built-in function
+ * with Nytris Boost in virtual filesystem mode.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class FiletypeTest extends AbstractFunctionalTestCase
+{
+    private Boost $boost;
+    private ContentsCacheInterface $contentsCache;
+    private CacheItemPoolInterface $realpathCachePool;
+    private CacheItemPoolInterface $statCachePool;
+
+    public function setUp(): void
+    {
+        $this->contentsCache = new SinglePoolContentsCache(new ArrayAdapter());
+        $this->realpathCachePool = new ArrayAdapter();
+        $this->statCachePool = new ArrayAdapter();
+
+        $this->boost = new Boost(
+            realpathCachePool: $this->realpathCachePool,
+            statCachePool: $this->statCachePool,
+            realpathCacheKey: '__my_realpath_cache',
+            statCacheKey: '__my_stat_cache',
+            contentsCache: $this->contentsCache,
+            // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
+            pathFilter: new FileFilter('/my/**'),
+            asVirtualFilesystem: true
+        );
+    }
+
+    public function tearDown(): void
+    {
+        $this->boost->uninstall();
+    }
+
+    public function testPlainFilesAreDetectedCorrectly(): void
+    {
+        $this->boost->install();
+        file_put_contents('/my/virtual/file.txt', 'my file contents');
+
+        static::assertSame('file', filetype('/my/virtual/file.txt'));
+    }
+
+    public function testDirectoriesAreDetectedCorrectly(): void
+    {
+        $this->boost->install();
+        mkdir('/my/virtual/dir', recursive: true);
+
+        static::assertSame('dir', filetype('/my/virtual/dir'));
+    }
+
+    public function testReturnsFalseForNonExistentFile(): void
+    {
+        $this->boost->install();
+
+        static::assertFalse(@filetype('/my/virtual/non_existent_file.txt'));
+    }
+}

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/FlockTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/FlockTest.php
@@ -45,8 +45,6 @@ class FlockTest extends AbstractFunctionalTestCase
         $this->boost = new Boost(
             realpathCachePool: $this->realpathCachePool,
             statCachePool: $this->statCachePool,
-            realpathCacheKey: '__my_realpath_cache',
-            statCacheKey: '__my_stat_cache',
             contentsCache: $this->contentsCache,
             // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
             pathFilter: new FileFilter('/my/**'),

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/FlockTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/FlockTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * Nytris Boost.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\Tests\Functional\VirtualFilesystemMode\FilesystemFunctions;
+
+use Asmblah\PhpCodeShift\Shifter\Filter\FileFilter;
+use Nytris\Boost\Boost;
+use Nytris\Boost\FsCache\Contents\ContentsCacheInterface;
+use Nytris\Boost\FsCache\Contents\SinglePoolContentsCache;
+use Nytris\Boost\Tests\Functional\AbstractFunctionalTestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * Class FlockTest.
+ *
+ * Tests the behaviour of the `flock(...)` built-in function
+ * with Nytris Boost in virtual filesystem mode.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class FlockTest extends AbstractFunctionalTestCase
+{
+    private Boost $boost;
+    private ContentsCacheInterface $contentsCache;
+    private CacheItemPoolInterface $realpathCachePool;
+    private CacheItemPoolInterface $statCachePool;
+
+    public function setUp(): void
+    {
+        $this->contentsCache = new SinglePoolContentsCache(new ArrayAdapter());
+        $this->realpathCachePool = new ArrayAdapter();
+        $this->statCachePool = new ArrayAdapter();
+
+        $this->boost = new Boost(
+            realpathCachePool: $this->realpathCachePool,
+            statCachePool: $this->statCachePool,
+            realpathCacheKey: '__my_realpath_cache',
+            statCacheKey: '__my_stat_cache',
+            contentsCache: $this->contentsCache,
+            // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
+            pathFilter: new FileFilter('/my/**'),
+            asVirtualFilesystem: true
+        );
+    }
+
+    public function tearDown(): void
+    {
+        $this->boost->uninstall();
+    }
+
+    public function testLockingAFileForSharedReadingSucceeds(): void
+    {
+        $this->boost->install();
+        $stream1 = fopen('/my/virtual/file.txt', 'rb+');
+        fwrite($stream1, 'my file contents');
+        fflush($stream1);
+
+        static::assertTrue(flock($stream1, LOCK_SH));
+        $stream2 = fopen('/my/virtual/file.txt', 'rb+');
+        static::assertTrue(flock($stream1, LOCK_SH));
+        static::assertSame('my file contents', fread($stream2, 1024));
+    }
+
+    public function testLockingAFileForExclusiveWritingSucceeds(): void
+    {
+        $this->boost->install();
+        $stream = fopen('/my/virtual/file.txt', 'rb+');
+        fwrite($stream, 'my file contents');
+        fflush($stream);
+        rewind($stream);
+
+        static::assertTrue(flock($stream, LOCK_EX));
+        static::assertSame('my file contents', fread($stream, 1024));
+    }
+}

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/FopenTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/FopenTest.php
@@ -45,8 +45,6 @@ class FopenTest extends AbstractFunctionalTestCase
         $this->boost = new Boost(
             realpathCachePool: $this->realpathCachePool,
             statCachePool: $this->statCachePool,
-            realpathCacheKey: '__my_realpath_cache',
-            statCacheKey: '__my_stat_cache',
             contentsCache: $this->contentsCache,
             // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
             pathFilter: new FileFilter('/my/**'),

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/FopenTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/FopenTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * Nytris Boost.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\Tests\Functional\VirtualFilesystemMode\FilesystemFunctions;
+
+use Asmblah\PhpCodeShift\Shifter\Filter\FileFilter;
+use Nytris\Boost\Boost;
+use Nytris\Boost\FsCache\Contents\ContentsCacheInterface;
+use Nytris\Boost\FsCache\Contents\SinglePoolContentsCache;
+use Nytris\Boost\Tests\Functional\AbstractFunctionalTestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * Class FopenTest.
+ *
+ * Tests the behaviour of the `fopen(...)` built-in function
+ * with Nytris Boost in virtual filesystem mode.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class FopenTest extends AbstractFunctionalTestCase
+{
+    private Boost $boost;
+    private ContentsCacheInterface $contentsCache;
+    private CacheItemPoolInterface $realpathCachePool;
+    private CacheItemPoolInterface $statCachePool;
+
+    public function setUp(): void
+    {
+        $this->contentsCache = new SinglePoolContentsCache(new ArrayAdapter());
+        $this->realpathCachePool = new ArrayAdapter();
+        $this->statCachePool = new ArrayAdapter();
+
+        $this->boost = new Boost(
+            realpathCachePool: $this->realpathCachePool,
+            statCachePool: $this->statCachePool,
+            realpathCacheKey: '__my_realpath_cache',
+            statCacheKey: '__my_stat_cache',
+            contentsCache: $this->contentsCache,
+            // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
+            pathFilter: new FileFilter('/my/**'),
+            asVirtualFilesystem: true
+        );
+    }
+
+    public function tearDown(): void
+    {
+        $this->boost->uninstall();
+    }
+
+    public function testCanOpenAFileForAppend(): void
+    {
+        $this->boost->install();
+        $stream1 = fopen('/my/virtual/file.txt', 'rb+');
+        fwrite($stream1, 'my file contents');
+        fclose($stream1);
+
+        $stream2 = fopen('/my/virtual/file.txt', 'ab');
+        fwrite($stream2, ' and some more');
+        fclose($stream2);
+
+        static::assertSame(
+            'my file contents and some more',
+            file_get_contents('/my/virtual/file.txt')
+        );
+    }
+}

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/FseekTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/FseekTest.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * Nytris Boost.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\Tests\Functional\VirtualFilesystemMode\FilesystemFunctions;
+
+use Asmblah\PhpCodeShift\Shifter\Filter\FileFilter;
+use Nytris\Boost\Boost;
+use Nytris\Boost\FsCache\Contents\ContentsCacheInterface;
+use Nytris\Boost\FsCache\Contents\SinglePoolContentsCache;
+use Nytris\Boost\Tests\Functional\AbstractFunctionalTestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * Class FseekTest.
+ *
+ * Tests the behaviour of the `fseek(...)` built-in function
+ * with Nytris Boost in virtual filesystem mode.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class FseekTest extends AbstractFunctionalTestCase
+{
+    private Boost $boost;
+    private ContentsCacheInterface $contentsCache;
+    private CacheItemPoolInterface $realpathCachePool;
+    private CacheItemPoolInterface $statCachePool;
+
+    public function setUp(): void
+    {
+        $this->contentsCache = new SinglePoolContentsCache(new ArrayAdapter());
+        $this->realpathCachePool = new ArrayAdapter();
+        $this->statCachePool = new ArrayAdapter();
+
+        $this->boost = new Boost(
+            realpathCachePool: $this->realpathCachePool,
+            statCachePool: $this->statCachePool,
+            realpathCacheKey: '__my_realpath_cache',
+            statCacheKey: '__my_stat_cache',
+            contentsCache: $this->contentsCache,
+            // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
+            pathFilter: new FileFilter('/my/**'),
+            asVirtualFilesystem: true
+        );
+    }
+
+    public function tearDown(): void
+    {
+        $this->boost->uninstall();
+    }
+
+    public function testCanSeekToASpecificOffsetWithinAFileStream(): void
+    {
+        $this->boost->install();
+        file_put_contents('/my/virtual/file.txt', 'my file contents');
+        $stream = fopen('/my/virtual/file.txt', 'rb+');
+
+        static::assertSame(0, fseek($stream, 4));
+        static::assertSame('ile contents', fread($stream, 1024));
+    }
+
+    public function testCanSeekRelativeToCurrentPositionOfAFileStream(): void
+    {
+        $this->boost->install();
+        file_put_contents('/my/virtual/file.txt', 'my file contents');
+        $stream = fopen('/my/virtual/file.txt', 'rb+');
+        fseek($stream, 4);
+
+        static::assertSame(0, fseek($stream, 3, SEEK_CUR));
+        static::assertSame(' contents', fread($stream, 1024));
+    }
+
+    public function testCanSeekRelativeToEndOfAFileStream(): void
+    {
+        $this->boost->install();
+        file_put_contents('/my/virtual/file.txt', 'my file contents');
+        $stream = fopen('/my/virtual/file.txt', 'rb+');
+
+        static::assertSame(0, fseek($stream, -5, SEEK_END));
+        static::assertSame('tents', fread($stream, 1024));
+    }
+}

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/FseekTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/FseekTest.php
@@ -45,8 +45,6 @@ class FseekTest extends AbstractFunctionalTestCase
         $this->boost = new Boost(
             realpathCachePool: $this->realpathCachePool,
             statCachePool: $this->statCachePool,
-            realpathCacheKey: '__my_realpath_cache',
-            statCacheKey: '__my_stat_cache',
             contentsCache: $this->contentsCache,
             // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
             pathFilter: new FileFilter('/my/**'),

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/FstatTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/FstatTest.php
@@ -45,8 +45,6 @@ class FstatTest extends AbstractFunctionalTestCase
         $this->boost = new Boost(
             realpathCachePool: $this->realpathCachePool,
             statCachePool: $this->statCachePool,
-            realpathCacheKey: '__my_realpath_cache',
-            statCacheKey: '__my_stat_cache',
             contentsCache: $this->contentsCache,
             // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
             pathFilter: new FileFilter('/my/**'),

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/FstatTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/FstatTest.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * Nytris Boost.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\Tests\Functional\VirtualFilesystemMode\FilesystemFunctions;
+
+use Asmblah\PhpCodeShift\Shifter\Filter\FileFilter;
+use Nytris\Boost\Boost;
+use Nytris\Boost\FsCache\Contents\ContentsCacheInterface;
+use Nytris\Boost\FsCache\Contents\SinglePoolContentsCache;
+use Nytris\Boost\Tests\Functional\AbstractFunctionalTestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * Class FstatTest.
+ *
+ * Tests the behaviour of the `fstat(...)` built-in function
+ * with Nytris Boost in virtual filesystem mode.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class FstatTest extends AbstractFunctionalTestCase
+{
+    private Boost $boost;
+    private ContentsCacheInterface $contentsCache;
+    private CacheItemPoolInterface $realpathCachePool;
+    private CacheItemPoolInterface $statCachePool;
+
+    public function setUp(): void
+    {
+        $this->contentsCache = new SinglePoolContentsCache(new ArrayAdapter());
+        $this->realpathCachePool = new ArrayAdapter();
+        $this->statCachePool = new ArrayAdapter();
+
+        $this->boost = new Boost(
+            realpathCachePool: $this->realpathCachePool,
+            statCachePool: $this->statCachePool,
+            realpathCacheKey: '__my_realpath_cache',
+            statCacheKey: '__my_stat_cache',
+            contentsCache: $this->contentsCache,
+            // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
+            pathFilter: new FileFilter('/my/**'),
+            asVirtualFilesystem: true
+        );
+    }
+
+    public function tearDown(): void
+    {
+        $this->boost->uninstall();
+    }
+
+    public function testReturnsCorrectStatusOfExistingFileInVirtualFilesystem(): void
+    {
+        $this->boost->install();
+        file_put_contents('/my/virtual/file.txt', 'my file contents');
+        $stream = fopen('/my/virtual/file.txt', 'rb');
+
+        $stat = fstat($stream);
+
+        static::assertSame(0100777, $stat['mode']);
+        static::assertSame(0100777, $stat[2]);
+        static::assertSame(16, $stat['size']);
+        static::assertSame(16, $stat[7]);
+    }
+
+    public function testReturnsCorrectStatusOfNewlyCreatedFileInVirtualFilesystem(): void
+    {
+        $this->boost->install();
+        $stream = fopen('/my/virtual/file.txt', 'rb+');
+
+        $stat = fstat($stream);
+
+        static::assertSame(0100777, $stat['mode']);
+        static::assertSame(0100777, $stat[2]);
+        static::assertSame(0, $stat['size']);
+        static::assertSame(0, $stat[7]);
+    }
+
+    public function testReturnsCorrectStatusOfExistingDirectoryInVirtualFilesystem(): void
+    {
+        $this->boost->install();
+        mkdir('/my/virtual/dir', recursive: true);
+        $stream = fopen('/my/virtual/dir', 'rb');
+
+        $stat = fstat($stream);
+
+        static::assertSame(0040777, $stat['mode']);
+        static::assertSame(0040777, $stat[2]);
+        static::assertSame(0, $stat['size']);
+        static::assertSame(0, $stat[7]);
+    }
+}

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/FtellTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/FtellTest.php
@@ -45,8 +45,6 @@ class FtellTest extends AbstractFunctionalTestCase
         $this->boost = new Boost(
             realpathCachePool: $this->realpathCachePool,
             statCachePool: $this->statCachePool,
-            realpathCacheKey: '__my_realpath_cache',
-            statCacheKey: '__my_stat_cache',
             contentsCache: $this->contentsCache,
             // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
             pathFilter: new FileFilter('/my/**'),

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/FtellTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/FtellTest.php
@@ -1,0 +1,70 @@
+<?php
+
+/*
+ * Nytris Boost.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\Tests\Functional\VirtualFilesystemMode\FilesystemFunctions;
+
+use Asmblah\PhpCodeShift\Shifter\Filter\FileFilter;
+use Nytris\Boost\Boost;
+use Nytris\Boost\FsCache\Contents\ContentsCacheInterface;
+use Nytris\Boost\FsCache\Contents\SinglePoolContentsCache;
+use Nytris\Boost\Tests\Functional\AbstractFunctionalTestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * Class FtellTest.
+ *
+ * Tests the behaviour of the `ftell(...)` built-in function
+ * with Nytris Boost in virtual filesystem mode.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class FtellTest extends AbstractFunctionalTestCase
+{
+    private Boost $boost;
+    private ContentsCacheInterface $contentsCache;
+    private CacheItemPoolInterface $realpathCachePool;
+    private CacheItemPoolInterface $statCachePool;
+
+    public function setUp(): void
+    {
+        $this->contentsCache = new SinglePoolContentsCache(new ArrayAdapter());
+        $this->realpathCachePool = new ArrayAdapter();
+        $this->statCachePool = new ArrayAdapter();
+
+        $this->boost = new Boost(
+            realpathCachePool: $this->realpathCachePool,
+            statCachePool: $this->statCachePool,
+            realpathCacheKey: '__my_realpath_cache',
+            statCacheKey: '__my_stat_cache',
+            contentsCache: $this->contentsCache,
+            // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
+            pathFilter: new FileFilter('/my/**'),
+            asVirtualFilesystem: true
+        );
+    }
+
+    public function tearDown(): void
+    {
+        $this->boost->uninstall();
+    }
+
+    public function testCanReadTheCurrentOffsetWithinAFileStream(): void
+    {
+        $this->boost->install();
+        $stream = fopen('/my/virtual/file.txt', 'rb+');
+        fwrite($stream, 'my file contents');
+
+        static::assertSame(16, ftell($stream));
+    }
+}

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/FtruncateTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/FtruncateTest.php
@@ -45,8 +45,6 @@ class FtruncateTest extends AbstractFunctionalTestCase
         $this->boost = new Boost(
             realpathCachePool: $this->realpathCachePool,
             statCachePool: $this->statCachePool,
-            realpathCacheKey: '__my_realpath_cache',
-            statCacheKey: '__my_stat_cache',
             contentsCache: $this->contentsCache,
             // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
             pathFilter: new FileFilter('/my/**'),

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/FtruncateTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/FtruncateTest.php
@@ -1,0 +1,82 @@
+<?php
+
+/*
+ * Nytris Boost.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\Tests\Functional\VirtualFilesystemMode\FilesystemFunctions;
+
+use Asmblah\PhpCodeShift\Shifter\Filter\FileFilter;
+use Nytris\Boost\Boost;
+use Nytris\Boost\FsCache\Contents\ContentsCacheInterface;
+use Nytris\Boost\FsCache\Contents\SinglePoolContentsCache;
+use Nytris\Boost\Tests\Functional\AbstractFunctionalTestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * Class FtruncateTest.
+ *
+ * Tests the behaviour of the `ftruncate(...)` built-in function
+ * with Nytris Boost in virtual filesystem mode.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class FtruncateTest extends AbstractFunctionalTestCase
+{
+    private Boost $boost;
+    private ContentsCacheInterface $contentsCache;
+    private CacheItemPoolInterface $realpathCachePool;
+    private CacheItemPoolInterface $statCachePool;
+
+    public function setUp(): void
+    {
+        $this->contentsCache = new SinglePoolContentsCache(new ArrayAdapter());
+        $this->realpathCachePool = new ArrayAdapter();
+        $this->statCachePool = new ArrayAdapter();
+
+        $this->boost = new Boost(
+            realpathCachePool: $this->realpathCachePool,
+            statCachePool: $this->statCachePool,
+            realpathCacheKey: '__my_realpath_cache',
+            statCacheKey: '__my_stat_cache',
+            contentsCache: $this->contentsCache,
+            // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
+            pathFilter: new FileFilter('/my/**'),
+            asVirtualFilesystem: true
+        );
+    }
+
+    public function tearDown(): void
+    {
+        $this->boost->uninstall();
+    }
+
+    public function testCanTruncateAFileStream(): void
+    {
+        $this->boost->install();
+        $stream = fopen('/my/virtual/file.txt', 'rb+');
+        fwrite($stream, 'my file contents');
+
+        static::assertTrue(ftruncate($stream, 8));
+        rewind($stream);
+        static::assertSame('my file ', fread($stream, 1024));
+    }
+
+    public function testDoesNotResetTheStreamPointer(): void
+    {
+        $this->boost->install();
+        $stream = fopen('/my/virtual/file.txt', 'rb+');
+        fwrite($stream, 'my file contents');
+
+        static::assertTrue(ftruncate($stream, 2));
+        static::assertSame(16, ftell($stream));
+    }
+}

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/IsDirTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/IsDirTest.php
@@ -45,8 +45,6 @@ class IsDirTest extends AbstractFunctionalTestCase
         $this->boost = new Boost(
             realpathCachePool: $this->realpathCachePool,
             statCachePool: $this->statCachePool,
-            realpathCacheKey: '__my_realpath_cache',
-            statCacheKey: '__my_stat_cache',
             contentsCache: $this->contentsCache,
             // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
             pathFilter: new FileFilter('/my/**'),

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/IsDirTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/IsDirTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/*
+ * Nytris Boost.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\Tests\Functional\VirtualFilesystemMode\FilesystemFunctions;
+
+use Asmblah\PhpCodeShift\Shifter\Filter\FileFilter;
+use Nytris\Boost\Boost;
+use Nytris\Boost\FsCache\Contents\ContentsCacheInterface;
+use Nytris\Boost\FsCache\Contents\SinglePoolContentsCache;
+use Nytris\Boost\Tests\Functional\AbstractFunctionalTestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * Class IsDirTest.
+ *
+ * Tests the behaviour of the `is_dir(...)` built-in function
+ * with Nytris Boost in virtual filesystem mode.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class IsDirTest extends AbstractFunctionalTestCase
+{
+    private Boost $boost;
+    private ContentsCacheInterface $contentsCache;
+    private CacheItemPoolInterface $realpathCachePool;
+    private CacheItemPoolInterface $statCachePool;
+
+    public function setUp(): void
+    {
+        $this->contentsCache = new SinglePoolContentsCache(new ArrayAdapter());
+        $this->realpathCachePool = new ArrayAdapter();
+        $this->statCachePool = new ArrayAdapter();
+
+        $this->boost = new Boost(
+            realpathCachePool: $this->realpathCachePool,
+            statCachePool: $this->statCachePool,
+            realpathCacheKey: '__my_realpath_cache',
+            statCacheKey: '__my_stat_cache',
+            contentsCache: $this->contentsCache,
+            // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
+            pathFilter: new FileFilter('/my/**'),
+            asVirtualFilesystem: true
+        );
+    }
+
+    public function tearDown(): void
+    {
+        $this->boost->uninstall();
+    }
+
+    public function testDirectoryExistenceMayBeCorrectlyTested(): void
+    {
+        $this->boost->install();
+        mkdir('/my/virtual/dir', recursive: true);
+
+        static::assertTrue(is_dir('/my/virtual/dir'));
+        static::assertFalse(is_dir('/my/virtual/non_existent_dir'));
+    }
+
+    public function testReturnsFalseForAFile(): void
+    {
+        $this->boost->install();
+        file_put_contents('/my/virtual/file.txt', 'my file contents');
+
+        static::assertFalse(is_dir('/my/virtual/file.txt'));
+    }
+}

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/IsExecutableTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/IsExecutableTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * Nytris Boost.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\Tests\Functional\VirtualFilesystemMode\FilesystemFunctions;
+
+use Asmblah\PhpCodeShift\Shifter\Filter\FileFilter;
+use Nytris\Boost\Boost;
+use Nytris\Boost\FsCache\Contents\ContentsCacheInterface;
+use Nytris\Boost\FsCache\Contents\SinglePoolContentsCache;
+use Nytris\Boost\Tests\Functional\AbstractFunctionalTestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * Class IsExecutableTest.
+ *
+ * Tests the behaviour of the `is_executable(...)` built-in function
+ * with Nytris Boost in virtual filesystem mode.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class IsExecutableTest extends AbstractFunctionalTestCase
+{
+    private Boost $boost;
+    private ContentsCacheInterface $contentsCache;
+    private CacheItemPoolInterface $realpathCachePool;
+    private CacheItemPoolInterface $statCachePool;
+
+    public function setUp(): void
+    {
+        $this->contentsCache = new SinglePoolContentsCache(new ArrayAdapter());
+        $this->realpathCachePool = new ArrayAdapter();
+        $this->statCachePool = new ArrayAdapter();
+
+        $this->boost = new Boost(
+            realpathCachePool: $this->realpathCachePool,
+            statCachePool: $this->statCachePool,
+            realpathCacheKey: '__my_realpath_cache',
+            statCacheKey: '__my_stat_cache',
+            contentsCache: $this->contentsCache,
+            // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
+            pathFilter: new FileFilter('/my/**'),
+            asVirtualFilesystem: true
+        );
+    }
+
+    public function tearDown(): void
+    {
+        $this->boost->uninstall();
+    }
+
+    public function testExistentExecutableFileIsExecutable(): void
+    {
+        $this->boost->install();
+        file_put_contents('/my/virtual/file.sh', 'my file contents');
+        chmod('/my/virtual/file.sh', 0777);
+
+        static::assertTrue(is_executable('/my/virtual/file.sh'));
+    }
+
+    public function testExistentNonExecutableFileIsNotExecutable(): void
+    {
+        $this->boost->install();
+        file_put_contents('/my/virtual/file.sh', 'my file contents');
+        chmod('/my/virtual/file.sh', 0444);
+
+        static::assertFalse(is_executable('/my/virtual/file.sh'));
+    }
+
+    public function testNonExistentFileIsNotExecutable(): void
+    {
+        $this->boost->install();
+
+        static::assertFalse(is_executable('/my/virtual/file.txt'));
+    }
+}

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/IsExecutableTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/IsExecutableTest.php
@@ -45,8 +45,6 @@ class IsExecutableTest extends AbstractFunctionalTestCase
         $this->boost = new Boost(
             realpathCachePool: $this->realpathCachePool,
             statCachePool: $this->statCachePool,
-            realpathCacheKey: '__my_realpath_cache',
-            statCacheKey: '__my_stat_cache',
             contentsCache: $this->contentsCache,
             // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
             pathFilter: new FileFilter('/my/**'),

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/IsFileTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/IsFileTest.php
@@ -1,0 +1,80 @@
+<?php
+
+/*
+ * Nytris Boost.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\Tests\Functional\VirtualFilesystemMode\FilesystemFunctions;
+
+use Asmblah\PhpCodeShift\Shifter\Filter\FileFilter;
+use Nytris\Boost\Boost;
+use Nytris\Boost\FsCache\Contents\ContentsCacheInterface;
+use Nytris\Boost\FsCache\Contents\SinglePoolContentsCache;
+use Nytris\Boost\Tests\Functional\AbstractFunctionalTestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * Class IsFileTest.
+ *
+ * Tests the behaviour of the `is_file(...)` built-in function
+ * with Nytris Boost in virtual filesystem mode.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class IsFileTest extends AbstractFunctionalTestCase
+{
+    private Boost $boost;
+    private ContentsCacheInterface $contentsCache;
+    private CacheItemPoolInterface $realpathCachePool;
+    private CacheItemPoolInterface $statCachePool;
+
+    public function setUp(): void
+    {
+        $this->contentsCache = new SinglePoolContentsCache(new ArrayAdapter());
+        $this->realpathCachePool = new ArrayAdapter();
+        $this->statCachePool = new ArrayAdapter();
+
+        $this->boost = new Boost(
+            realpathCachePool: $this->realpathCachePool,
+            statCachePool: $this->statCachePool,
+            realpathCacheKey: '__my_realpath_cache',
+            statCacheKey: '__my_stat_cache',
+            contentsCache: $this->contentsCache,
+            // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
+            pathFilter: new FileFilter('/my/**'),
+            asVirtualFilesystem: true
+        );
+    }
+
+    public function tearDown(): void
+    {
+        $this->boost->uninstall();
+    }
+
+    public function testFileExistenceMayBeCorrectlyTested(): void
+    {
+        $this->boost->install();
+
+        file_put_contents('/my/virtual/file.txt', 'my file contents');
+
+        static::assertTrue(is_file('/my/virtual/file.txt'));
+        static::assertFalse(is_file('/my/virtual/non_existent_file.txt'));
+    }
+
+    public function testReturnsFalseForADirectory(): void
+    {
+        $this->boost->install();
+
+        mkdir('/my/virtual/dir');
+
+        static::assertFalse(is_file('/my/virtual/dir'));
+    }
+}

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/IsFileTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/IsFileTest.php
@@ -45,8 +45,6 @@ class IsFileTest extends AbstractFunctionalTestCase
         $this->boost = new Boost(
             realpathCachePool: $this->realpathCachePool,
             statCachePool: $this->statCachePool,
-            realpathCacheKey: '__my_realpath_cache',
-            statCacheKey: '__my_stat_cache',
             contentsCache: $this->contentsCache,
             // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
             pathFilter: new FileFilter('/my/**'),

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/IsReadableTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/IsReadableTest.php
@@ -45,8 +45,6 @@ class IsReadableTest extends AbstractFunctionalTestCase
         $this->boost = new Boost(
             realpathCachePool: $this->realpathCachePool,
             statCachePool: $this->statCachePool,
-            realpathCacheKey: '__my_realpath_cache',
-            statCacheKey: '__my_stat_cache',
             contentsCache: $this->contentsCache,
             // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
             pathFilter: new FileFilter('/my/**'),

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/IsReadableTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/IsReadableTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * Nytris Boost.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\Tests\Functional\VirtualFilesystemMode\FilesystemFunctions;
+
+use Asmblah\PhpCodeShift\Shifter\Filter\FileFilter;
+use Nytris\Boost\Boost;
+use Nytris\Boost\FsCache\Contents\ContentsCacheInterface;
+use Nytris\Boost\FsCache\Contents\SinglePoolContentsCache;
+use Nytris\Boost\Tests\Functional\AbstractFunctionalTestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * Class IsReadableTest.
+ *
+ * Tests the behaviour of the `is_readable(...)` built-in function
+ * with Nytris Boost in virtual filesystem mode.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class IsReadableTest extends AbstractFunctionalTestCase
+{
+    private Boost $boost;
+    private ContentsCacheInterface $contentsCache;
+    private CacheItemPoolInterface $realpathCachePool;
+    private CacheItemPoolInterface $statCachePool;
+
+    public function setUp(): void
+    {
+        $this->contentsCache = new SinglePoolContentsCache(new ArrayAdapter());
+        $this->realpathCachePool = new ArrayAdapter();
+        $this->statCachePool = new ArrayAdapter();
+
+        $this->boost = new Boost(
+            realpathCachePool: $this->realpathCachePool,
+            statCachePool: $this->statCachePool,
+            realpathCacheKey: '__my_realpath_cache',
+            statCacheKey: '__my_stat_cache',
+            contentsCache: $this->contentsCache,
+            // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
+            pathFilter: new FileFilter('/my/**'),
+            asVirtualFilesystem: true
+        );
+    }
+
+    public function tearDown(): void
+    {
+        $this->boost->uninstall();
+    }
+
+    public function testExistentFileIsReadable(): void
+    {
+        $this->boost->install();
+
+        file_put_contents('/my/virtual/file.txt', 'my file contents');
+
+        static::assertTrue(is_readable('/my/virtual/file.txt'));
+    }
+
+    public function testNonExistentFileIsNotReadable(): void
+    {
+        $this->boost->install();
+
+        static::assertFalse(is_readable('/my/virtual/file.txt'));
+    }
+
+    public function testFileWithoutReadPermissionIsNotReadable(): void
+    {
+        $this->boost->install();
+
+        file_put_contents('/my/virtual/file.txt', 'my file contents');
+        chmod('/my/virtual/file.txt', 0);
+
+        static::assertFalse(is_readable('/my/virtual/file.txt'));
+    }
+}

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/IsWritableTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/IsWritableTest.php
@@ -45,8 +45,6 @@ class IsWritableTest extends AbstractFunctionalTestCase
         $this->boost = new Boost(
             realpathCachePool: $this->realpathCachePool,
             statCachePool: $this->statCachePool,
-            realpathCacheKey: '__my_realpath_cache',
-            statCacheKey: '__my_stat_cache',
             contentsCache: $this->contentsCache,
             // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
             pathFilter: new FileFilter('/my/**'),

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/IsWritableTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/IsWritableTest.php
@@ -1,0 +1,86 @@
+<?php
+
+/*
+ * Nytris Boost.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\Tests\Functional\VirtualFilesystemMode\FilesystemFunctions;
+
+use Asmblah\PhpCodeShift\Shifter\Filter\FileFilter;
+use Nytris\Boost\Boost;
+use Nytris\Boost\FsCache\Contents\ContentsCacheInterface;
+use Nytris\Boost\FsCache\Contents\SinglePoolContentsCache;
+use Nytris\Boost\Tests\Functional\AbstractFunctionalTestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * Class IsWritableTest.
+ *
+ * Tests the behaviour of the `is_writable(...)` built-in function
+ * with Nytris Boost in virtual filesystem mode.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class IsWritableTest extends AbstractFunctionalTestCase
+{
+    private Boost $boost;
+    private ContentsCacheInterface $contentsCache;
+    private CacheItemPoolInterface $realpathCachePool;
+    private CacheItemPoolInterface $statCachePool;
+
+    public function setUp(): void
+    {
+        $this->contentsCache = new SinglePoolContentsCache(new ArrayAdapter());
+        $this->realpathCachePool = new ArrayAdapter();
+        $this->statCachePool = new ArrayAdapter();
+
+        $this->boost = new Boost(
+            realpathCachePool: $this->realpathCachePool,
+            statCachePool: $this->statCachePool,
+            realpathCacheKey: '__my_realpath_cache',
+            statCacheKey: '__my_stat_cache',
+            contentsCache: $this->contentsCache,
+            // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
+            pathFilter: new FileFilter('/my/**'),
+            asVirtualFilesystem: true
+        );
+    }
+
+    public function tearDown(): void
+    {
+        $this->boost->uninstall();
+    }
+
+    public function testExistentWritableFileIsWritable(): void
+    {
+        $this->boost->install();
+        file_put_contents('/my/virtual/file.txt', 'my file contents');
+
+        static::assertTrue(is_writable('/my/virtual/file.txt'));
+    }
+
+    public function testExistentNonWritableFileIsNotWritable(): void
+    {
+        $this->boost->install();
+        file_put_contents('/my/virtual/file.txt', 'my file contents');
+        chmod('/my/virtual/file.txt', 0444);
+
+        static::assertFalse(is_writable('/my/virtual/file.txt'));
+    }
+
+    public function testNonExistentFileIsNotWritable(): void
+    {
+        $this->boost->install();
+
+        // Counter-intuitive, but this is the behaviour for normal filesystem access too.
+        static::assertFalse(is_writable('/my/virtual/file.txt'));
+    }
+}

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/LstatTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/LstatTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * Nytris Boost.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\Tests\Functional\VirtualFilesystemMode\FilesystemFunctions;
+
+use Asmblah\PhpCodeShift\Shifter\Filter\FileFilter;
+use Nytris\Boost\Boost;
+use Nytris\Boost\FsCache\Contents\ContentsCacheInterface;
+use Nytris\Boost\FsCache\Contents\SinglePoolContentsCache;
+use Nytris\Boost\Tests\Functional\AbstractFunctionalTestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * Class LstatTest.
+ *
+ * Tests the behaviour of the `lstat(...)` built-in function
+ * with Nytris Boost in virtual filesystem mode.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class LstatTest extends AbstractFunctionalTestCase
+{
+    private Boost $boost;
+    private ContentsCacheInterface $contentsCache;
+    private CacheItemPoolInterface $realpathCachePool;
+    private CacheItemPoolInterface $statCachePool;
+
+    public function setUp(): void
+    {
+        $this->contentsCache = new SinglePoolContentsCache(new ArrayAdapter());
+        $this->realpathCachePool = new ArrayAdapter();
+        $this->statCachePool = new ArrayAdapter();
+
+        $this->boost = new Boost(
+            realpathCachePool: $this->realpathCachePool,
+            statCachePool: $this->statCachePool,
+            realpathCacheKey: '__my_realpath_cache',
+            statCacheKey: '__my_stat_cache',
+            contentsCache: $this->contentsCache,
+            // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
+            pathFilter: new FileFilter('/my/**'),
+            asVirtualFilesystem: true
+        );
+    }
+
+    public function tearDown(): void
+    {
+        $this->boost->uninstall();
+    }
+
+    public function testReturnsCorrectStatusOfFileInVirtualFilesystem(): void
+    {
+        $this->boost->install();
+        file_put_contents('/my/virtual/file.txt', 'my file contents');
+
+        $stat = lstat('/my/virtual/file.txt');
+
+        static::assertSame(0100777, $stat['mode']);
+        static::assertSame(0100777, $stat[2]);
+        static::assertSame(16, $stat['size']);
+        static::assertSame(16, $stat[7]);
+    }
+
+    public function testReturnsCorrectStatusOfDirectoryInVirtualFilesystem(): void
+    {
+        $this->boost->install();
+        mkdir('/my/virtual/dir', recursive: true);
+
+        $stat = lstat('/my/virtual/dir');
+
+        static::assertSame(0040777, $stat['mode']);
+        static::assertSame(0040777, $stat[2]);
+        static::assertSame(0, $stat['size']);
+        static::assertSame(0, $stat[7]);
+    }
+
+    public function testReturnsFalseForNonExistentFile(): void
+    {
+        $this->boost->install();
+
+        static::assertFalse(@lstat('/my/virtual/non_existent_file.txt'));
+    }
+}

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/MkdirTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/MkdirTest.php
@@ -1,0 +1,101 @@
+<?php
+
+/*
+ * Nytris Boost.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\Tests\Functional\VirtualFilesystemMode\FilesystemFunctions;
+
+use Asmblah\PhpCodeShift\Shifter\Filter\FileFilter;
+use Asmblah\PhpCodeShift\Shifter\Filter\MultipleFilter;
+use Nytris\Boost\Boost;
+use Nytris\Boost\FsCache\Contents\ContentsCacheInterface;
+use Nytris\Boost\FsCache\Contents\SinglePoolContentsCache;
+use Nytris\Boost\Tests\Functional\AbstractFunctionalTestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * Class MkdirTest.
+ *
+ * Tests the behaviour of the `mkdir(...)` built-in function
+ * with Nytris Boost in virtual filesystem mode.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class MkdirTest extends AbstractFunctionalTestCase
+{
+    private Boost $boost;
+    private ContentsCacheInterface $contentsCache;
+    private CacheItemPoolInterface $realpathCachePool;
+    private CacheItemPoolInterface $statCachePool;
+
+    public function setUp(): void
+    {
+        $this->contentsCache = new SinglePoolContentsCache(new ArrayAdapter());
+        $this->realpathCachePool = new ArrayAdapter();
+        $this->statCachePool = new ArrayAdapter();
+
+        $this->boost = new Boost(
+            realpathCachePool: $this->realpathCachePool,
+            statCachePool: $this->statCachePool,
+            realpathCacheKey: '__my_realpath_cache',
+            statCacheKey: '__my_stat_cache',
+            contentsCache: $this->contentsCache,
+            // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
+            pathFilter: new MultipleFilter([
+                new FileFilter('/my'),
+                new FileFilter('/my/**'),
+            ]),
+            asVirtualFilesystem: true
+        );
+    }
+
+    public function tearDown(): void
+    {
+        $this->boost->uninstall();
+    }
+
+    public function testDirectoriesCanBeCreatedRecursively(): void
+    {
+        $this->boost->install();
+        mkdir('/my/virtual/dir', recursive: true);
+
+        static::assertTrue(is_dir('/my'));
+        static::assertTrue(is_dir('/my/virtual'));
+        static::assertTrue(is_dir('/my/virtual/dir'));
+    }
+
+    public function testCanCreateANewDirectoryWithinAnExistingOneInNonRecursiveMode(): void
+    {
+        $this->boost->install();
+        mkdir('/my/virtual', recursive: true);
+
+        static::assertTrue(mkdir('/my/virtual/dir'));
+        static::assertTrue(is_dir('/my/virtual/dir'));
+    }
+
+    public function testCannotCreateANewDirectoryWithinANonExistingOneInNonRecursiveMode(): void
+    {
+        $this->boost->install();
+
+        static::assertFalse(mkdir('/my/virtual/dir'));
+        static::assertFalse(is_dir('/my/virtual/dir'));
+    }
+
+    public function testCannotCreateADirectoryWhenItAlreadyExists(): void
+    {
+        $this->boost->install();
+        mkdir('/my/virtual/dir', recursive: true);
+
+        static::assertFalse(mkdir('/my/virtual/dir'));
+        static::assertTrue(is_dir('/my/virtual/dir'));
+    }
+}

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/MkdirTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/MkdirTest.php
@@ -46,8 +46,6 @@ class MkdirTest extends AbstractFunctionalTestCase
         $this->boost = new Boost(
             realpathCachePool: $this->realpathCachePool,
             statCachePool: $this->statCachePool,
-            realpathCacheKey: '__my_realpath_cache',
-            statCacheKey: '__my_stat_cache',
             contentsCache: $this->contentsCache,
             // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
             pathFilter: new MultipleFilter([

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/OpendirTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/OpendirTest.php
@@ -47,8 +47,6 @@ class OpendirTest extends AbstractFunctionalTestCase
         $this->boost = new Boost(
             realpathCachePool: $this->realpathCachePool,
             statCachePool: $this->statCachePool,
-            realpathCacheKey: '__my_realpath_cache',
-            statCacheKey: '__my_stat_cache',
             contentsCache: $this->contentsCache,
             // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
             pathFilter: new MultipleFilter([

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/OpendirTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/OpendirTest.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * Nytris Boost.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\Tests\Functional\VirtualFilesystemMode\FilesystemFunctions;
+
+use Asmblah\PhpCodeShift\Shifter\Filter\FileFilter;
+use Asmblah\PhpCodeShift\Shifter\Filter\MultipleFilter;
+use LogicException;
+use Nytris\Boost\Boost;
+use Nytris\Boost\FsCache\Contents\ContentsCacheInterface;
+use Nytris\Boost\FsCache\Contents\SinglePoolContentsCache;
+use Nytris\Boost\Tests\Functional\AbstractFunctionalTestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * Class OpendirTest.
+ *
+ * Tests the behaviour of the `opendir(...)` built-in function
+ * with Nytris Boost in virtual filesystem mode.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class OpendirTest extends AbstractFunctionalTestCase
+{
+    private Boost $boost;
+    private ContentsCacheInterface $contentsCache;
+    private CacheItemPoolInterface $realpathCachePool;
+    private CacheItemPoolInterface $statCachePool;
+
+    public function setUp(): void
+    {
+        $this->contentsCache = new SinglePoolContentsCache(new ArrayAdapter());
+        $this->realpathCachePool = new ArrayAdapter();
+        $this->statCachePool = new ArrayAdapter();
+
+        $this->boost = new Boost(
+            realpathCachePool: $this->realpathCachePool,
+            statCachePool: $this->statCachePool,
+            realpathCacheKey: '__my_realpath_cache',
+            statCacheKey: '__my_stat_cache',
+            contentsCache: $this->contentsCache,
+            // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
+            pathFilter: new MultipleFilter([
+                new FileFilter('/my'),
+                new FileFilter('/my/**'),
+            ]),
+            asVirtualFilesystem: true
+        );
+    }
+
+    public function tearDown(): void
+    {
+        $this->boost->uninstall();
+    }
+
+    public function testDirectoryEnumerationIsNotYetSupported(): void
+    {
+        $this->boost->install();
+        mkdir('/my/virtual/dir/first', recursive: true);
+        mkdir('/my/virtual/dir/second');
+        mkdir('/my/virtual/dir/third');
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage(
+            'Virtual filesystem does not yet support opening directory "/my/virtual/dir" for enumeration'
+        );
+
+        opendir('/my/virtual/dir');
+    }
+}

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/RenameTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/RenameTest.php
@@ -22,25 +22,29 @@ use Psr\Cache\CacheItemPoolInterface;
 use Symfony\Component\Cache\Adapter\ArrayAdapter;
 
 /**
- * Class LstatTest.
+ * Class RenameTest.
  *
- * Tests the behaviour of the `lstat(...)` built-in function
+ * Tests the behaviour of the `rename(...)` built-in function
  * with Nytris Boost in virtual filesystem mode.
  *
  * @author Dan Phillimore <dan@ovms.co>
  */
-class LstatTest extends AbstractFunctionalTestCase
+class RenameTest extends AbstractFunctionalTestCase
 {
     private Boost $boost;
     private ContentsCacheInterface $contentsCache;
     private CacheItemPoolInterface $realpathCachePool;
     private CacheItemPoolInterface $statCachePool;
+    private string $varPath;
 
     public function setUp(): void
     {
         $this->contentsCache = new SinglePoolContentsCache(new ArrayAdapter());
         $this->realpathCachePool = new ArrayAdapter();
         $this->statCachePool = new ArrayAdapter();
+
+        $this->varPath = dirname(__DIR__, 4) . '/var/test';
+        @mkdir($this->varPath, recursive: true);
 
         $this->boost = new Boost(
             realpathCachePool: $this->realpathCachePool,
@@ -55,38 +59,20 @@ class LstatTest extends AbstractFunctionalTestCase
     public function tearDown(): void
     {
         $this->boost->uninstall();
+
+        $this->rimrafDescendantsOf($this->varPath);
     }
 
-    public function testReturnsCorrectStatusOfFileInVirtualFilesystem(): void
+    public function testCanMoveAnExistingFileFromAndToVirtualFilesystem(): void
     {
+        $sourcePath = '/my/virtual/source_file.txt';
+        $destinationPath = '/my/virtual/dest_file.txt';
         $this->boost->install();
-        file_put_contents('/my/virtual/file.txt', 'my file contents');
+        file_put_contents($sourcePath, 'my file contents');
 
-        $stat = lstat('/my/virtual/file.txt');
-
-        static::assertSame(0100777, $stat['mode']);
-        static::assertSame(0100777, $stat[2]);
-        static::assertSame(16, $stat['size']);
-        static::assertSame(16, $stat[7]);
-    }
-
-    public function testReturnsCorrectStatusOfDirectoryInVirtualFilesystem(): void
-    {
-        $this->boost->install();
-        mkdir('/my/virtual/dir', recursive: true);
-
-        $stat = lstat('/my/virtual/dir');
-
-        static::assertSame(0040777, $stat['mode']);
-        static::assertSame(0040777, $stat[2]);
-        static::assertSame(0, $stat['size']);
-        static::assertSame(0, $stat[7]);
-    }
-
-    public function testReturnsFalseForNonExistentFile(): void
-    {
-        $this->boost->install();
-
-        static::assertFalse(@lstat('/my/virtual/non_existent_file.txt'));
+        static::assertTrue(rename($sourcePath, $destinationPath));
+        static::assertFalse(is_file($sourcePath));
+        static::assertTrue(is_file($destinationPath));
+        static::assertSame('my file contents', file_get_contents($destinationPath));
     }
 }

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/StatTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/StatTest.php
@@ -45,8 +45,6 @@ class StatTest extends AbstractFunctionalTestCase
         $this->boost = new Boost(
             realpathCachePool: $this->realpathCachePool,
             statCachePool: $this->statCachePool,
-            realpathCacheKey: '__my_realpath_cache',
-            statCacheKey: '__my_stat_cache',
             contentsCache: $this->contentsCache,
             // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
             pathFilter: new FileFilter('/my/**'),

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/StatTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/StatTest.php
@@ -1,0 +1,94 @@
+<?php
+
+/*
+ * Nytris Boost.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\Tests\Functional\VirtualFilesystemMode\FilesystemFunctions;
+
+use Asmblah\PhpCodeShift\Shifter\Filter\FileFilter;
+use Nytris\Boost\Boost;
+use Nytris\Boost\FsCache\Contents\ContentsCacheInterface;
+use Nytris\Boost\FsCache\Contents\SinglePoolContentsCache;
+use Nytris\Boost\Tests\Functional\AbstractFunctionalTestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * Class StatTest.
+ *
+ * Tests the behaviour of the `stat(...)` built-in function
+ * with Nytris Boost in virtual filesystem mode.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class StatTest extends AbstractFunctionalTestCase
+{
+    private Boost $boost;
+    private ContentsCacheInterface $contentsCache;
+    private CacheItemPoolInterface $realpathCachePool;
+    private CacheItemPoolInterface $statCachePool;
+
+    public function setUp(): void
+    {
+        $this->contentsCache = new SinglePoolContentsCache(new ArrayAdapter());
+        $this->realpathCachePool = new ArrayAdapter();
+        $this->statCachePool = new ArrayAdapter();
+
+        $this->boost = new Boost(
+            realpathCachePool: $this->realpathCachePool,
+            statCachePool: $this->statCachePool,
+            realpathCacheKey: '__my_realpath_cache',
+            statCacheKey: '__my_stat_cache',
+            contentsCache: $this->contentsCache,
+            // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
+            pathFilter: new FileFilter('/my/**'),
+            asVirtualFilesystem: true
+        );
+    }
+
+    public function tearDown(): void
+    {
+        $this->boost->uninstall();
+    }
+
+    public function testReturnsCorrectStatusOfFileInVirtualFilesystem(): void
+    {
+        $this->boost->install();
+        file_put_contents('/my/virtual/file.txt', 'my file contents');
+
+        $stat = stat('/my/virtual/file.txt');
+
+        static::assertSame(0100777, $stat['mode']);
+        static::assertSame(0100777, $stat[2]);
+        static::assertSame(16, $stat['size']);
+        static::assertSame(16, $stat[7]);
+    }
+
+    public function testReturnsCorrectStatusOfDirectoryInVirtualFilesystem(): void
+    {
+        $this->boost->install();
+        mkdir('/my/virtual/dir', recursive: true);
+
+        $stat = stat('/my/virtual/dir');
+
+        static::assertSame(0040777, $stat['mode']);
+        static::assertSame(0040777, $stat[2]);
+        static::assertSame(0, $stat['size']);
+        static::assertSame(0, $stat[7]);
+    }
+
+    public function testReturnsFalseForNonExistentFile(): void
+    {
+        $this->boost->install();
+
+        static::assertFalse(@stat('/my/virtual/non_existent_file.txt'));
+    }
+}

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/TouchTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/TouchTest.php
@@ -150,10 +150,25 @@ class TouchTest extends AbstractFunctionalTestCase
         static::assertSame(1726739486, $stat[8]);
     }
 
-    public function testReturnsFalseForNonExistentFile(): void
+    public function testCreatesNonExistentFileWhenNeitherModificationNorAccessTimestampsSpecified(): void
     {
+        $path = '/my/virtual/non_existent_file.txt';
+        $this->environment->allows()
+            ->getStartTime()
+            ->andReturn(1726739986);
+        $this->environment->allows()
+            ->getTime()
+            ->andReturn(1726749987);
         $this->boost->install();
 
-        static::assertFalse(@touch('/my/virtual/non_existent_file.txt'));
+        static::assertTrue(touch($path));
+        static::assertTrue(is_file($path));
+        $stat = stat($path);
+        static::assertSame(1726749987, $stat['mtime'], 'Should use current system time');
+        static::assertSame(1726749987, $stat[9]);
+        static::assertSame(1726749987, $stat['atime'], 'Should use current system time');
+        static::assertSame(1726749987, $stat[8]);
+        static::assertSame(0, $stat['size'], 'Should use 0 as the size');
+        static::assertSame(0, $stat[7]);
     }
 }

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/TouchTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/TouchTest.php
@@ -57,8 +57,6 @@ class TouchTest extends AbstractFunctionalTestCase
             library: new Library($this->environment),
             realpathCachePool: $this->realpathCachePool,
             statCachePool: $this->statCachePool,
-            realpathCacheKey: '__my_realpath_cache',
-            statCacheKey: '__my_stat_cache',
             contentsCache: $this->contentsCache,
             // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
             pathFilter: new FileFilter('/my/**'),

--- a/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/TouchTest.php
+++ b/tests/Functional/VirtualFilesystemMode/FilesystemFunctions/TouchTest.php
@@ -1,0 +1,161 @@
+<?php
+
+/*
+ * Nytris Boost.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\Tests\Functional\VirtualFilesystemMode\FilesystemFunctions;
+
+use Asmblah\PhpCodeShift\Shifter\Filter\FileFilter;
+use Mockery\MockInterface;
+use Nytris\Boost\Boost;
+use Nytris\Boost\Environment\EnvironmentInterface;
+use Nytris\Boost\FsCache\Contents\ContentsCacheInterface;
+use Nytris\Boost\FsCache\Contents\SinglePoolContentsCache;
+use Nytris\Boost\Library\Library;
+use Nytris\Boost\Tests\Functional\AbstractFunctionalTestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * Class TouchTest.
+ *
+ * Tests the behaviour of the `touch(...)` built-in function
+ * with Nytris Boost in virtual filesystem mode.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class TouchTest extends AbstractFunctionalTestCase
+{
+    private Boost $boost;
+    private ContentsCacheInterface $contentsCache;
+    private MockInterface&EnvironmentInterface $environment;
+    private CacheItemPoolInterface $realpathCachePool;
+    private CacheItemPoolInterface $statCachePool;
+
+    public function setUp(): void
+    {
+        $this->contentsCache = new SinglePoolContentsCache(new ArrayAdapter());
+        $this->environment = mock(EnvironmentInterface::class, [
+            'getCwd' => '/my/virtual/cwd',
+            'getStartTime' => 1726739286,
+        ]);
+        $this->realpathCachePool = new ArrayAdapter();
+        $this->statCachePool = new ArrayAdapter();
+
+        // Load Mockery internals for the stub as there is a catch-22 with the path filtering.
+        $this->environment->getCwd();
+
+        $this->boost = new Boost(
+            library: new Library($this->environment),
+            realpathCachePool: $this->realpathCachePool,
+            statCachePool: $this->statCachePool,
+            realpathCacheKey: '__my_realpath_cache',
+            statCacheKey: '__my_stat_cache',
+            contentsCache: $this->contentsCache,
+            // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
+            pathFilter: new FileFilter('/my/**'),
+            asVirtualFilesystem: true
+        );
+    }
+
+    public function tearDown(): void
+    {
+        $this->boost->uninstall();
+    }
+
+    public function testCanCorrectlyChangeModificationTimestampOfAFileInVirtualFilesystem(): void
+    {
+        $this->boost->install();
+        file_put_contents('/my/virtual/file.txt', 'my file contents');
+
+        static::assertTrue(touch('/my/virtual/file.txt', mtime: 1726739486));
+        $stat = stat('/my/virtual/file.txt');
+        static::assertSame(1726739486, $stat['mtime']);
+        static::assertSame(1726739486, $stat[9]);
+    }
+
+    public function testCanCorrectlyTouchWithNeitherModificationNorAccessTimestampsSpecified(): void
+    {
+        $this->environment->allows()
+            ->getStartTime()
+            ->andReturn(1726739986);
+        $this->environment->allows()
+            ->getTime()
+            ->andReturn(1726749987);
+        $this->boost->install();
+        file_put_contents('/my/virtual/file.txt', 'my file contents');
+
+        static::assertTrue(touch('/my/virtual/file.txt'));
+        $stat = stat('/my/virtual/file.txt');
+        static::assertSame(1726749987, $stat['mtime'], 'Should use current system time');
+        static::assertSame(1726749987, $stat[9]);
+        static::assertSame(1726749987, $stat['atime'], 'Should use current system time');
+        static::assertSame(1726749987, $stat[8]);
+    }
+
+    public function testCanCorrectlyTouchWithOnlyModificationTimestampSpecified(): void
+    {
+        $this->environment->allows()
+            ->getStartTime()
+            ->andReturn(1726739986);
+        $this->boost->install();
+        file_put_contents('/my/virtual/file.txt', 'my file contents');
+
+        static::assertTrue(touch('/my/virtual/file.txt', mtime: 1726749987));
+        $stat = stat('/my/virtual/file.txt');
+        static::assertSame(1726749987, $stat['mtime']);
+        static::assertSame(1726749987, $stat[9]);
+        static::assertSame(1726749987, $stat['atime']);
+        static::assertSame(1726749987, $stat[8]);
+    }
+
+    public function testCanCorrectlyChangeModificationTimestampOfADirectoryInVirtualFilesystem(): void
+    {
+        $this->boost->install();
+        mkdir('/my/virtual/dir', recursive: true);
+
+        static::assertTrue(touch('/my/virtual/dir', mtime: 1726739486));
+        $stat = stat('/my/virtual/dir');
+        static::assertSame(1726739486, $stat['mtime']);
+        static::assertSame(1726739486, $stat[9]);
+    }
+
+    public function testCanCorrectlyChangeAccessTimestampOfAFileInVirtualFilesystem(): void
+    {
+        $this->boost->install();
+        file_put_contents('/my/virtual/file.txt', 'my file contents');
+
+        /** @noinspection PotentialMalwareInspection */
+        static::assertTrue(touch('/my/virtual/file.txt', mtime: 1726739386, atime: 1726739486));
+        $stat = stat('/my/virtual/file.txt');
+        static::assertSame(1726739486, $stat['atime']);
+        static::assertSame(1726739486, $stat[8]);
+    }
+
+    public function testCanCorrectlyChangeAccessTimestampOfADirectoryInVirtualFilesystem(): void
+    {
+        $this->boost->install();
+        mkdir('/my/virtual/dir', recursive: true);
+
+        /** @noinspection PotentialMalwareInspection */
+        static::assertTrue(touch('/my/virtual/dir', mtime: 1726739386, atime: 1726739486));
+        $stat = stat('/my/virtual/dir');
+        static::assertSame(1726739486, $stat['atime']);
+        static::assertSame(1726739486, $stat[8]);
+    }
+
+    public function testReturnsFalseForNonExistentFile(): void
+    {
+        $this->boost->install();
+
+        static::assertFalse(@touch('/my/virtual/non_existent_file.txt'));
+    }
+}

--- a/tests/Functional/VirtualFilesystemMode/IncludeTest.php
+++ b/tests/Functional/VirtualFilesystemMode/IncludeTest.php
@@ -49,8 +49,6 @@ class IncludeTest extends AbstractFunctionalTestCase
         $this->boost = new Boost(
             realpathCachePool: $this->realpathCachePool,
             statCachePool: $this->statCachePool,
-            realpathCacheKey: '__my_realpath_cache',
-            statCacheKey: '__my_stat_cache',
             contentsCache: $this->contentsCache,
             // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
             pathFilter: new FileFilter('/my/**'),

--- a/tests/Functional/VirtualFilesystemMode/IncludeTest.php
+++ b/tests/Functional/VirtualFilesystemMode/IncludeTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * Nytris Boost.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\Tests\Functional\VirtualFilesystemMode;
+
+use Asmblah\PhpCodeShift\CodeShift;
+use Asmblah\PhpCodeShift\CodeShiftInterface;
+use Asmblah\PhpCodeShift\Shifter\Filter\FileFilter;
+use Asmblah\PhpCodeShift\Shifter\Shift\Shift\String\StringLiteralShiftSpec;
+use Nytris\Boost\Boost;
+use Nytris\Boost\FsCache\Contents\ContentsCacheInterface;
+use Nytris\Boost\FsCache\Contents\SinglePoolContentsCache;
+use Nytris\Boost\Tests\Functional\AbstractFunctionalTestCase;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * Class IncludeTest.
+ *
+ * Tests the behaviour of PHP module inclusion with Nytris Boost in virtual filesystem mode.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class IncludeTest extends AbstractFunctionalTestCase
+{
+    private Boost $boost;
+    private CodeShiftInterface $codeShift;
+    private ContentsCacheInterface $contentsCache;
+    private CacheItemPoolInterface $realpathCachePool;
+    private CacheItemPoolInterface $statCachePool;
+
+    public function setUp(): void
+    {
+        $this->codeShift = new CodeShift();
+        $this->contentsCache = new SinglePoolContentsCache(new ArrayAdapter());
+        $this->realpathCachePool = new ArrayAdapter();
+        $this->statCachePool = new ArrayAdapter();
+
+        $this->boost = new Boost(
+            realpathCachePool: $this->realpathCachePool,
+            statCachePool: $this->statCachePool,
+            realpathCacheKey: '__my_realpath_cache',
+            statCacheKey: '__my_stat_cache',
+            contentsCache: $this->contentsCache,
+            // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
+            pathFilter: new FileFilter('/my/**'),
+            asVirtualFilesystem: true
+        );
+    }
+
+    public function tearDown(): void
+    {
+        $this->boost->uninstall();
+        $this->codeShift->uninstall();
+    }
+
+    public function testShiftsMayBeAppliedToModulesInVirtualFilesystem(): void
+    {
+        $modulePath = '/my/path/to/my_module.php';
+        $this->codeShift->shift(
+            new StringLiteralShiftSpec('hello there', 'well good day to you'),
+            new FileFilter('/my/**')
+        );
+        $this->boost->install();
+        mkdir(dirname($modulePath), recursive: true);
+        file_put_contents($modulePath, <<<PHP
+<?php
+
+return 'I said hello there';
+PHP);
+
+        static::assertSame(
+            'I said well good day to you',
+            include $modulePath
+        );
+    }
+}

--- a/tests/Functional/VirtualFilesystemMode/OpcacheTest.php
+++ b/tests/Functional/VirtualFilesystemMode/OpcacheTest.php
@@ -1,0 +1,95 @@
+<?php
+
+/*
+ * Nytris Boost.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\Tests\Functional\VirtualFilesystemMode;
+
+use Asmblah\PhpCodeShift\CodeShift;
+use Asmblah\PhpCodeShift\CodeShiftInterface;
+use Asmblah\PhpCodeShift\Shifter\Filter\FileFilter;
+use Nytris\Boost\Boost;
+use Nytris\Boost\FsCache\Contents\ContentsCacheInterface;
+use Nytris\Boost\FsCache\Contents\SinglePoolContentsCache;
+use Nytris\Boost\Tests\Functional\AbstractFunctionalTestCase;
+use Nytris\Boost\Tests\Functional\Fixtures\HookedLogic;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * Class OpcacheTest.
+ *
+ * Tests the virtual filesystem behaviour in conjunction with OPcache.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class OpcacheTest extends AbstractFunctionalTestCase
+{
+    private Boost $boost;
+    private CodeShiftInterface $codeShift;
+    private ContentsCacheInterface $contentsCache;
+    private CacheItemPoolInterface $realpathCachePool;
+    private CacheItemPoolInterface $statCachePool;
+
+    public function setUp(): void
+    {
+        if (
+            !extension_loaded('Zend OPcache') ||
+            !ini_get('opcache.enable') ||
+            !ini_get('opcache.enable_cli')
+        ) {
+            $this->markTestSkipped('Zend OPcache is not installed.');
+        }
+
+        $this->codeShift = new CodeShift();
+        $this->contentsCache = new SinglePoolContentsCache(new ArrayAdapter());
+        $this->realpathCachePool = new ArrayAdapter();
+        $this->statCachePool = new ArrayAdapter();
+
+        $this->boost = new Boost(
+            realpathCachePool: $this->realpathCachePool,
+            statCachePool: $this->statCachePool,
+            contentsCache: $this->contentsCache,
+            // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
+            pathFilter: new FileFilter('/my/**'),
+            asVirtualFilesystem: true
+        );
+    }
+
+    public function tearDown(): void
+    {
+        $this->boost->uninstall();
+        $this->codeShift->uninstall();
+    }
+
+    public function testVirtualFileMayBeCompiledEditedAndRecompiled(): void
+    {
+        $path = '/my/path/to/virtual_file.php';
+        $this->boost->install();
+        file_put_contents($path, '<?php return "my first result";');
+
+        static::assertTrue(opcache_compile_file($path));
+        static::assertSame('my first result', include $path);
+        static::assertTrue(opcache_is_script_cached($path));
+        // See notes in HookedLogic for why `opcache_invalidate(...)` cannot be called directly here.
+        static::assertTrue((new HookedLogic())->callOpcacheInvalidate($path, force: true));
+
+        static::assertNotFalse(file_put_contents($path, '<?php return "my second result";'));
+        static::assertTrue(opcache_compile_file($path));
+        static::assertSame('my second result', include $path);
+        static::assertTrue(opcache_is_script_cached($path));
+
+        static::assertNotFalse(file_put_contents($path, '<?php return "my third result";'));
+        // Due to no invalidation being performed, the second variant should remain cached.
+        static::assertSame('my second result', include $path);
+        static::assertTrue(opcache_is_script_cached($path));
+    }
+}

--- a/tests/Functional/VirtualFilesystemMode/SymfonyCache/PhpFilesAdapterTest.php
+++ b/tests/Functional/VirtualFilesystemMode/SymfonyCache/PhpFilesAdapterTest.php
@@ -1,0 +1,109 @@
+<?php
+
+/*
+ * Nytris Boost.
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\Tests\Functional\VirtualFilesystemMode\SymfonyCache;
+
+use Asmblah\PhpCodeShift\Shifter\Filter\FileFilter;
+use Nytris\Boost\Boost;
+use Nytris\Boost\FsCache\Contents\ContentsCacheInterface;
+use Nytris\Boost\FsCache\Contents\SinglePoolContentsCache;
+use Nytris\Boost\Tests\Functional\AbstractFunctionalTestCase;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+use Symfony\Component\Cache\Adapter\PhpFilesAdapter;
+
+/**
+ * Class PhpFilesAdapterTest.
+ *
+ * Tests the virtual filesystem in conjunction with Symfony Cache's PhpFilesAdapter and OPcache.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class PhpFilesAdapterTest extends AbstractFunctionalTestCase
+{
+    private PhpFilesAdapter $adapter;
+    private Boost $boost;
+    private ContentsCacheInterface $contentsCache;
+    private CacheItemPoolInterface $realpathCachePool;
+    private CacheItemPoolInterface $statCachePool;
+
+    public function setUp(): void
+    {
+        if (
+            !extension_loaded('Zend OPcache') ||
+            !ini_get('opcache.enable') ||
+            !ini_get('opcache.enable_cli')
+        ) {
+            $this->markTestSkipped('Zend OPcache is not installed.');
+        }
+
+        $this->contentsCache = new SinglePoolContentsCache(new ArrayAdapter());
+        $this->realpathCachePool = new ArrayAdapter();
+        $this->statCachePool = new ArrayAdapter();
+
+        $this->boost = new Boost(
+            realpathCachePool: $this->realpathCachePool,
+            statCachePool: $this->statCachePool,
+            contentsCache: $this->contentsCache,
+            // Avoid affecting test harness filesystem access, e.g. when autoloading Mockery classes.
+            pathFilter: new FileFilter('/my/**'),
+            asVirtualFilesystem: true
+        );
+
+        $this->boost->install();
+
+        $this->adapter = new PhpFilesAdapter(directory: '/my/virtual/var/cache');
+    }
+
+    public function tearDown(): void
+    {
+        $this->boost->uninstall();
+    }
+
+    public function testItemsMayBeSetAndFetched(): void
+    {
+        mkdir('/my/virtual/var/cache');
+        /** @var CacheItemInterface $item */
+        $item = $this->adapter->getItem('my_key');
+        $item->set('my value');
+        $this->adapter->save($item);
+
+        /** @var CacheItemInterface $item */
+        $item = $this->adapter->getItem('my_key');
+
+        static::assertTrue($item->isHit());
+        static::assertSame('my value', $item->get());
+    }
+
+    public function testItemsMayBeChanged(): void
+    {
+        mkdir('/my/virtual/var/cache');
+        /** @var CacheItemInterface $item */
+        $item = $this->adapter->getItem('my_key');
+        $item->set('my first value');
+        $this->adapter->save($item);
+        $this->adapter->commit();
+
+        /** @var CacheItemInterface $item */
+        $item = $this->adapter->getItem('my_key');
+        $item->set('my second value');
+        $this->adapter->save($item);
+        $this->adapter->commit();
+        /** @var CacheItemInterface $item */
+        $item = $this->adapter->getItem('my_key');
+
+        static::assertTrue($item->isHit());
+        static::assertSame('my second value', $item->get());
+    }
+}

--- a/tests/Unit/BoostPackageTest.php
+++ b/tests/Unit/BoostPackageTest.php
@@ -13,6 +13,8 @@ declare(strict_types=1);
 
 namespace Nytris\Boost\Tests\Unit;
 
+use Asmblah\PhpCodeShift\Shifter\Filter\FileFilter;
+use Asmblah\PhpCodeShift\Shifter\Filter\FileFilterInterface;
 use Nytris\Boost\BoostPackage;
 use Nytris\Boost\Charge;
 use Nytris\Boost\Tests\AbstractTestCase;
@@ -25,6 +27,31 @@ use Psr\Cache\CacheItemPoolInterface;
  */
 class BoostPackageTest extends AbstractTestCase
 {
+    public function testGetHookBuiltinFunctionsFilterReturnsWildcardFilterWhenSetToTrue(): void
+    {
+        $package = new BoostPackage(hookBuiltinFunctions: true);
+
+        $filter = $package->getHookBuiltinFunctionsFilter();
+
+        static::assertInstanceOf(FileFilter::class, $filter);
+        static::assertSame('**', $filter->getPattern());
+    }
+
+    public function testGetHookBuiltinFunctionsFilterReturnsGivenFilterWhenSetToAFilterInstance(): void
+    {
+        $filter = mock(FileFilterInterface::class);
+        $package = new BoostPackage(hookBuiltinFunctions: $filter);
+
+        static::assertSame($filter, $package->getHookBuiltinFunctionsFilter());
+    }
+
+    public function testGetHookBuiltinFunctionsFilterReturnsNullWhenSetToFalse(): void
+    {
+        $package = new BoostPackage(hookBuiltinFunctions: false);
+
+        static::assertNull($package->getHookBuiltinFunctionsFilter());
+    }
+
     public function testGetPackageFacadeFqcnReturnsCorrectFqcn(): void
     {
         $package = new BoostPackage();
@@ -124,19 +151,5 @@ class BoostPackageTest extends AbstractTestCase
         $package = new BoostPackage(cacheNonExistentFiles: false);
 
         static::assertFalse($package->shouldCacheNonExistentFiles());
-    }
-
-    public function testShouldHookBuiltinFunctionsReturnsTrueWhenSet(): void
-    {
-        $package = new BoostPackage(hookBuiltinFunctions: true);
-
-        static::assertTrue($package->shouldHookBuiltinFunctions());
-    }
-
-    public function testShouldHookBuiltinFunctionsReturnsFalseWhenSet(): void
-    {
-        $package = new BoostPackage(hookBuiltinFunctions: false);
-
-        static::assertFalse($package->shouldHookBuiltinFunctions());
     }
 }

--- a/tests/Unit/BoostPackageTest.php
+++ b/tests/Unit/BoostPackageTest.php
@@ -98,6 +98,20 @@ class BoostPackageTest extends AbstractTestCase
         static::assertNull($package->getStatCachePool('/my/cache/path'));
     }
 
+    public function testIsVirtualFilesystemReturnsTrueWhenSet(): void
+    {
+        $package = new BoostPackage(asVirtualFilesystem: true);
+
+        static::assertTrue($package->isVirtualFilesystem());
+    }
+
+    public function testIsVirtualFilesystemReturnsFalseWhenSet(): void
+    {
+        $package = new BoostPackage(asVirtualFilesystem: false);
+
+        static::assertFalse($package->isVirtualFilesystem());
+    }
+
     public function testShouldCacheNonExistentFilesReturnsTrueWhenSet(): void
     {
         $package = new BoostPackage(cacheNonExistentFiles: true);

--- a/tests/Unit/FsCache/CanonicaliserTest.php
+++ b/tests/Unit/FsCache/CanonicaliserTest.php
@@ -14,6 +14,8 @@ declare(strict_types=1);
 namespace Nytris\Boost\Tests\Unit\FsCache;
 
 use Generator;
+use Mockery\MockInterface;
+use Nytris\Boost\Environment\EnvironmentInterface;
 use Nytris\Boost\FsCache\Canonicaliser;
 use Nytris\Boost\Tests\AbstractTestCase;
 
@@ -25,10 +27,13 @@ use Nytris\Boost\Tests\AbstractTestCase;
 class CanonicaliserTest extends AbstractTestCase
 {
     private Canonicaliser $canonicaliser;
+    private MockInterface&EnvironmentInterface $environment;
 
     public function setUp(): void
     {
-        $this->canonicaliser = new Canonicaliser();
+        $this->environment = mock(EnvironmentInterface::class);
+
+        $this->canonicaliser = new Canonicaliser($this->environment);
     }
 
     /**
@@ -103,5 +108,17 @@ class CanonicaliserTest extends AbstractTestCase
             '/home/my/sub/path',
             '/home/you/',
         ];
+    }
+
+    public function testCanonicaliseFetchesCwdFromEnvironmentWhenNotSpecified(): void
+    {
+        $this->environment->allows()
+            ->getCwd()
+            ->andReturn('/my/canonical');
+
+        static::assertSame(
+            '/my/canonical/path/to/stuff.txt',
+            $this->canonicaliser->canonicalise('./path/to/stuff.txt')
+        );
     }
 }

--- a/tests/Unit/FsCache/CanonicaliserTest.php
+++ b/tests/Unit/FsCache/CanonicaliserTest.php
@@ -121,4 +121,12 @@ class CanonicaliserTest extends AbstractTestCase
             $this->canonicaliser->canonicalise('./path/to/stuff.txt')
         );
     }
+
+    public function testCanonicaliseCacheKeyReturnsCanonicalisedResult(): void
+    {
+        static::assertSame(
+            hash('sha256', 'my_key'),
+            $this->canonicaliser->canonicaliseCacheKey('my_key')
+        );
+    }
 }

--- a/tests/Unit/FsCache/Realpath/RealpathCacheTest.php
+++ b/tests/Unit/FsCache/Realpath/RealpathCacheTest.php
@@ -150,4 +150,23 @@ class RealpathCacheTest extends AbstractTestCase
 
         $this->realpathCache->persistRealpathCache();
     }
+
+    public function testSetBackingCacheEntryStoresInMemoryCache(): void
+    {
+        $item = mock(CacheItemInterface::class, [
+            'isHit' => false,
+            'set' => null,
+        ]);
+        $this->realpathCachePool->allows()
+            ->getItem('canonicalised--_my_real_path')
+            ->andReturn($item);
+        $this->realpathCachePool->allows('saveDeferred');
+
+        $this->realpathCache->setBackingCacheEntry('/my/real/path', ['my' => 'entry']);
+
+        static::assertEquals(
+            ['my' => 'entry'],
+            $this->realpathCache->getBackingCacheEntry('/my/real/path')
+        );
+    }
 }

--- a/tests/Unit/FsCache/Realpath/RealpathCacheTest.php
+++ b/tests/Unit/FsCache/Realpath/RealpathCacheTest.php
@@ -17,6 +17,7 @@ use Asmblah\PhpCodeShift\Shifter\Stream\Handler\StreamHandlerInterface;
 use Mockery\MockInterface;
 use Nytris\Boost\FsCache\CanonicaliserInterface;
 use Nytris\Boost\FsCache\Realpath\RealpathCache;
+use Nytris\Boost\FsCache\Realpath\RealpathCacheInterface;
 use Nytris\Boost\Tests\AbstractTestCase;
 use Psr\Cache\CacheItemInterface;
 use Psr\Cache\CacheItemPoolInterface;
@@ -39,14 +40,7 @@ class RealpathCacheTest extends AbstractTestCase
     {
         $this->canonicaliser = mock(CanonicaliserInterface::class);
         $this->realpathCachePool = mock(CacheItemPoolInterface::class);
-        $this->realpathCachePoolItem = mock(CacheItemInterface::class, [
-            'get' => [
-                '/my/resolved/../path/to/my_module.php' => [
-                    'canonical' => '/my/path/to/my_module.php',
-                ],
-            ],
-            'isHit' => true,
-        ]);
+        $this->realpathCachePoolItem = mock(CacheItemInterface::class);
         $this->wrappedStreamHandler = mock(StreamHandlerInterface::class);
 
         $this->canonicaliser->allows('canonicalise')
@@ -56,11 +50,6 @@ class RealpathCacheTest extends AbstractTestCase
             ->andReturnUsing(fn (string $key) => 'canonicalised--' . preg_replace('#\W#', '_', $key))
             ->byDefault();
 
-        $this->realpathCachePool->allows()
-            ->getItem('my_realpath_cache_key')
-            ->andReturn($this->realpathCachePoolItem)
-            ->byDefault();
-
         $this->wrappedStreamHandler->allows('unwrapped')
             ->andReturnUsing(fn (callable $callback) => $callback())
             ->byDefault();
@@ -68,9 +57,44 @@ class RealpathCacheTest extends AbstractTestCase
         $this->realpathCache = new RealpathCache(
             $this->wrappedStreamHandler,
             $this->canonicaliser,
-            $this->realpathCachePool,
+            realpathPreloadCachePool: null,
+            realpathCachePool: $this->realpathCachePool,
             cacheNonExistentFiles: true,
             asVirtualFilesystem: false
+        );
+    }
+
+    public function testConstructorLoadsInMemoryCacheFromPreloadPoolWhenProvided(): void
+    {
+        $preloadCachePool = mock(CacheItemPoolInterface::class);
+        $preloadItem = mock(CacheItemInterface::class, [
+            'get' => [
+                '/my/first/path' => ['realpath' => '/my/first/realpath'],
+                '/my/second/path' => ['realpath' => '/my/second/realpath'],
+            ],
+            'isHit' => true,
+        ]);
+
+        $preloadCachePool->expects()
+            ->getItem(RealpathCacheInterface::PRELOAD_CACHE_KEY)
+            ->andReturn($preloadItem)
+            ->once();
+
+        $this->realpathCache = new RealpathCache(
+            $this->wrappedStreamHandler,
+            $this->canonicaliser,
+            realpathPreloadCachePool: $preloadCachePool,
+            realpathCachePool: $this->realpathCachePool,
+            cacheNonExistentFiles: true,
+            asVirtualFilesystem: false
+        );
+
+        static::assertEquals(
+            [
+                '/my/first/path' => ['realpath' => '/my/first/realpath'],
+                '/my/second/path' => ['realpath' => '/my/second/realpath'],
+            ],
+            $this->realpathCache->getInMemoryEntryCache()
         );
     }
 
@@ -79,7 +103,8 @@ class RealpathCacheTest extends AbstractTestCase
         $this->realpathCache = new RealpathCache(
             $this->wrappedStreamHandler,
             $this->canonicaliser,
-            new ArrayAdapter(),
+            realpathPreloadCachePool: null,
+            realpathCachePool: new ArrayAdapter(),
             cacheNonExistentFiles: true,
             asVirtualFilesystem: false
         );
@@ -108,12 +133,129 @@ class RealpathCacheTest extends AbstractTestCase
         );
     }
 
+    public function testDeleteBackingCacheEntryDeletesFromInMemoryCache(): void
+    {
+        $this->realpathCachePool->allows()
+            ->deleteItem('canonicalised--_my_real_path')
+            ->andReturnTrue();
+
+        $this->realpathCache->deleteBackingCacheEntry('/my/real/path');
+
+        static::assertEquals(
+            [],
+            $this->realpathCache->getInMemoryEntryCache()
+        );
+    }
+
+    public function testDeleteBackingCacheEntryDeletesFromPsrBackingCache(): void
+    {
+        $this->realpathCachePool->expects()
+            ->deleteItem('canonicalised--_my_real_path')
+            ->once()
+            ->andReturnTrue();
+
+        $this->realpathCache->deleteBackingCacheEntry('/my/real/path');
+    }
+
+    public function testGetBackingCacheEntryPrefersInMemoryCache(): void
+    {
+        $this->realpathCache->setInMemoryCacheEntry('/my/real/path', ['my' => 'entry']);
+
+        $this->realpathCachePool->expects('getItem')
+            ->never();
+
+        static::assertEquals(
+            ['my' => 'entry'],
+            $this->realpathCache->getBackingCacheEntry('/my/real/path')
+        );
+    }
+
+    public function testGetBackingCacheEntryFetchesFromPsrBackingCacheWhenNotInMemoryCache(): void
+    {
+        $this->realpathCachePool->allows()
+            ->getItem('canonicalised--_my_real_path')
+            ->andReturn($this->realpathCachePoolItem);
+        $this->realpathCachePoolItem->allows()
+            ->get()
+            ->andReturn(['my' => 'entry']);
+        $this->realpathCachePoolItem->allows()
+            ->isHit()
+            ->andReturnTrue();
+
+        static::assertEquals(
+            ['my' => 'entry'],
+            $this->realpathCache->getBackingCacheEntry('/my/real/path')
+        );
+    }
+
+    public function testGetCachedEventualPathFetchesPresentPathWithoutHittingPsrBackingCache(): void
+    {
+        $accessible = false;
+        $this->realpathCache->setInMemoryCacheEntry(
+            '/my/canonical/../path',
+            ['canonical' => '/my/canonical/path']
+        );
+        $this->realpathCache->setInMemoryCacheEntry(
+            '/my/canonical/path',
+            ['realpath' => '/my/real/path']
+        );
+
+        static::assertSame(
+            '/my/real/path',
+            $this->realpathCache->getCachedEventualPath(
+                '/my/canonical/../path',
+                accessible: $accessible
+            )
+        );
+        static::assertTrue($accessible);
+    }
+
+    public function testGetCachedEventualPathMarksAccessibleFalseWhenCachedAsNonExistent(): void
+    {
+        $accessible = false;
+        $this->realpathCache->setInMemoryCacheEntry(
+            '/my/canonical/../path',
+            ['canonical' => '/my/canonical/path']
+        );
+        $this->realpathCache->setInMemoryCacheEntry(
+            '/my/canonical/path',
+            ['realpath' => '/my/real/path', 'exists' => false]
+        );
+
+        static::assertSame(
+            '/my/real/path',
+            $this->realpathCache->getCachedEventualPath(
+                '/my/canonical/../path',
+                accessible: $accessible
+            )
+        );
+        static::assertFalse($accessible);
+    }
+
+    public function testGetInMemoryEntryCacheReturnsEmptyArrayInitially(): void
+    {
+        static::assertEquals([], $this->realpathCache->getInMemoryEntryCache());
+    }
+
+    public function testGetRealpathReturnsRealpathForExistingFile(): void
+    {
+        $this->realpathCache->setInMemoryCacheEntry('/my/test/path', [
+            'realpath' => '/my/real/path',
+        ]);
+
+        static::assertEquals(
+            '/my/real/path',
+            $this->realpathCache->getRealpath('/my/test/path')
+        );
+    }
+
     public function testGetRealpathCachesNonExistentFileWhenEnabled(): void
     {
         $this->realpathCache = new RealpathCache(
             $this->wrappedStreamHandler,
             $this->canonicaliser,
-            new ArrayAdapter(),
+            realpathPreloadCachePool: null,
+            realpathCachePool: new ArrayAdapter(),
             cacheNonExistentFiles: true,
             asVirtualFilesystem: false
         );
@@ -133,13 +275,160 @@ class RealpathCacheTest extends AbstractTestCase
         $this->realpathCache = new RealpathCache(
             $this->wrappedStreamHandler,
             $this->canonicaliser,
-            new ArrayAdapter(),
+            realpathPreloadCachePool: null,
+            realpathCachePool: new ArrayAdapter(),
             cacheNonExistentFiles: false, // Disable caching of non-existent files.
             asVirtualFilesystem: false
         );
 
         static::assertNull($this->realpathCache->getRealpath($path));
         static::assertNull($this->realpathCache->getRealpathCacheEntry($path, followSymlinks: true));
+    }
+
+    public function testGetRealpathCacheEntryReturnsCorrectEntryForDirectAccessWhenCached(): void
+    {
+        $this->realpathCache->setInMemoryCacheEntry('/my/test/path', ['realpath' => '/my/real/path']);
+
+        static::assertEquals(
+            ['realpath' => '/my/real/path'],
+            $this->realpathCache->getRealpathCacheEntry('/my/test/path', followSymlinks: true)
+        );
+    }
+
+    public function testGetRealpathCacheEntryReturnsCorrectEntryUsingCanonicalPathWhenCached(): void
+    {
+        $this->realpathCache->setInMemoryCacheEntry('/my/test/path', ['canonical' => '/my/canonical/path']);
+        $this->realpathCache->setInMemoryCacheEntry('/my/canonical/path', ['realpath' => '/my/real/path']);
+
+        static::assertEquals(
+            ['realpath' => '/my/real/path'],
+            $this->realpathCache->getRealpathCacheEntry('/my/test/path', followSymlinks: true)
+        );
+    }
+
+    public function testGetRealpathCacheEntryReturnsCorrectEntryUsingCanonicalAndSymlinkPathsWhenCachedAndEnabled(): void
+    {
+        $this->realpathCache->setInMemoryCacheEntry('/my/test/path', ['canonical' => '/my/canonical/path']);
+        $this->realpathCache->setInMemoryCacheEntry('/my/canonical/path', ['symlink' => '/my/symlink/path']);
+        $this->realpathCache->setInMemoryCacheEntry('/my/symlink/path', ['realpath' => '/my/real/path']);
+
+        static::assertEquals(
+            ['realpath' => '/my/real/path'],
+            $this->realpathCache->getRealpathCacheEntry('/my/test/path', followSymlinks: true)
+        );
+    }
+
+    public function testGetRealpathCacheEntryReturnsCorrectEntryUsingCanonicalAndSymlinkPathsWhenCachedButDisabled(): void
+    {
+        $this->realpathCache->setInMemoryCacheEntry('/my/test/path', ['canonical' => '/my/canonical/path']);
+        $this->realpathCache->setInMemoryCacheEntry('/my/canonical/path', ['symlink' => '/my/symlink/path']);
+        $this->realpathCache->setInMemoryCacheEntry('/my/symlink/path', ['realpath' => '/my/real/path']);
+
+        static::assertEquals(
+            // Note that symlink cache entry is not followed through to and fetched when flag is off.
+            ['symlink' => '/my/symlink/path'],
+            $this->realpathCache->getRealpathCacheEntry('/my/test/path', followSymlinks: false)
+        );
+    }
+
+    public function testGetRealpathCacheEntryReturnsNullWhenNotCached(): void
+    {
+        $this->realpathCachePool->allows()
+            ->getItem('canonicalised--_my_unknown_path')
+            ->andReturn($this->realpathCachePoolItem);
+        $this->realpathCachePoolItem->allows()
+            ->isHit()
+            ->andReturnFalse();
+
+        static::assertNull($this->realpathCache->getRealpathCacheEntry('/my/unknown/path', followSymlinks: true));
+    }
+
+    public function testGetRealpathCacheEntryReturnsNullWhenOnlyCanonicalisationIsCached(): void
+    {
+        $this->realpathCache->setInMemoryCacheEntry('/my/unknown/path', [
+            'canonical' => '/my/canonical/unknown/path',
+        ]);
+        $this->realpathCachePool->allows()
+            ->getItem('canonicalised--_my_canonical_unknown_path')
+            ->andReturn($this->realpathCachePoolItem);
+        $this->realpathCachePoolItem->allows()
+            ->isHit()
+            ->andReturnFalse();
+
+        static::assertNull($this->realpathCache->getRealpathCacheEntry('/my/unknown/path', followSymlinks: true));
+    }
+
+    public function testInvalidateClearsInMemoryCache(): void
+    {
+        $this->realpathCachePool->allows('clear');
+        $this->realpathCache->setInMemoryCacheEntry('/my/test/path', ['realpath' => '/my/real/path']);
+
+        $this->realpathCache->invalidate();
+
+        static::assertEquals([], $this->realpathCache->getInMemoryEntryCache());
+    }
+
+    public function testInvalidateClearsPsrBackingCache(): void
+    {
+        $this->realpathCache->setInMemoryCacheEntry('/my/test/path', ['realpath' => '/my/real/path']);
+
+        $this->realpathCachePool->expects()
+            ->clear()
+            ->once();
+
+        $this->realpathCache->invalidate();
+    }
+
+    public function testInvalidatePathClearsCanonicalAndEventualEntriesFromInMemoryCache(): void
+    {
+        $this->canonicaliser->allows()
+            ->canonicalise('/my/first/path')
+            ->andReturn('/my/canonical/first/path');
+        $this->canonicaliser->allows()
+            ->canonicalise('/my/second/path')
+            ->andReturn('/my/canonical/second/path');
+        $this->realpathCachePool->allows('deleteItem');
+        $this->realpathCache->setInMemoryCacheEntry('/my/first/path', [
+            'canonical' => '/my/canonical/first/path',
+        ]);
+        $this->realpathCache->setInMemoryCacheEntry('/my/canonical/first/path', [
+            'realpath' => '/my/real/first/path',
+        ]);
+        $this->realpathCache->setInMemoryCacheEntry('/my/second/path', [
+            'canonical' => '/my/canonical/second/path',
+        ]);
+        $this->realpathCache->setInMemoryCacheEntry('/my/canonical/second/path', [
+            'realpath' => '/my/real/second/path',
+        ]);
+
+        $this->realpathCache->invalidatePath('/my/second/path');
+
+        static::assertEquals(
+            [
+                '/my/first/path' => ['canonical' => '/my/canonical/first/path'],
+                '/my/canonical/first/path' => ['realpath' => '/my/real/first/path'],
+                // Note that canonical entries are left in place.
+                // This is because there are an infinite number of paths that canonicalise
+                // to a particular one, so it is more efficient to simply remove their target entry.
+                '/my/second/path' => ['canonical' => '/my/canonical/second/path'],
+            ],
+            $this->realpathCache->getInMemoryEntryCache()
+        );
+    }
+
+    public function testInvalidatePathClearsCanonicalAndEventualEntriesFromPsrBackingCache(): void
+    {
+        $this->realpathCache->setInMemoryCacheEntry('/my/first/path', ['realpath' => '/my/real/first/path']);
+        $this->realpathCache->setInMemoryCacheEntry('/my/second/path', ['realpath' => '/my/real/second/path']);
+
+        $this->realpathCachePool->expects()
+            ->deleteItem('canonicalised--_my_second_path')
+            ->once();
+        $this->realpathCachePool->expects()
+            ->deleteItem('canonicalised--_my_real_second_path')
+            ->once();
+
+        $this->realpathCache->invalidatePath('/my/second/path');
     }
 
     public function testPersistRealpathCachePersistsBackingStore(): void
@@ -167,6 +456,22 @@ class RealpathCacheTest extends AbstractTestCase
         static::assertEquals(
             ['my' => 'entry'],
             $this->realpathCache->getBackingCacheEntry('/my/real/path')
+        );
+        static::assertEquals(
+            [
+                '/my/real/path' => ['my' => 'entry'],
+            ],
+            $this->realpathCache->getInMemoryEntryCache()
+        );
+    }
+
+    public function testSetInMemoryCacheEntryStoresEntry(): void
+    {
+        $this->realpathCache->setInMemoryCacheEntry('/my/test/path', ['realpath' => '/my/real/path']);
+
+        static::assertEquals(
+            ['realpath' => '/my/real/path'],
+            $this->realpathCache->getBackingCacheEntry('/my/test/path')
         );
     }
 }

--- a/tests/Unit/FsCache/Realpath/RealpathCacheTest.php
+++ b/tests/Unit/FsCache/Realpath/RealpathCacheTest.php
@@ -1,0 +1,153 @@
+<?php
+
+/*
+ * Nytris Boost
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\Tests\Unit\FsCache\Realpath;
+
+use Asmblah\PhpCodeShift\Shifter\Stream\Handler\StreamHandlerInterface;
+use Mockery\MockInterface;
+use Nytris\Boost\FsCache\CanonicaliserInterface;
+use Nytris\Boost\FsCache\Realpath\RealpathCache;
+use Nytris\Boost\Tests\AbstractTestCase;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+use Symfony\Component\Cache\Adapter\ArrayAdapter;
+
+/**
+ * Class RealpathCacheTest.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class RealpathCacheTest extends AbstractTestCase
+{
+    private MockInterface&CanonicaliserInterface $canonicaliser;
+    private RealpathCache $realpathCache;
+    private MockInterface&CacheItemPoolInterface $realpathCachePool;
+    private MockInterface&CacheItemInterface $realpathCachePoolItem;
+    private MockInterface&StreamHandlerInterface $wrappedStreamHandler;
+
+    public function setUp(): void
+    {
+        $this->canonicaliser = mock(CanonicaliserInterface::class);
+        $this->realpathCachePool = mock(CacheItemPoolInterface::class);
+        $this->realpathCachePoolItem = mock(CacheItemInterface::class, [
+            'get' => [
+                '/my/resolved/../path/to/my_module.php' => [
+                    'canonical' => '/my/path/to/my_module.php',
+                ],
+            ],
+            'isHit' => true,
+        ]);
+        $this->wrappedStreamHandler = mock(StreamHandlerInterface::class);
+
+        $this->canonicaliser->allows('canonicalise')
+            ->andReturnArg(0)
+            ->byDefault();
+        $this->canonicaliser->allows('canonicaliseCacheKey')
+            ->andReturnUsing(fn (string $key) => 'canonicalised--' . preg_replace('#\W#', '_', $key))
+            ->byDefault();
+
+        $this->realpathCachePool->allows()
+            ->getItem('my_realpath_cache_key')
+            ->andReturn($this->realpathCachePoolItem)
+            ->byDefault();
+
+        $this->wrappedStreamHandler->allows('unwrapped')
+            ->andReturnUsing(fn (callable $callback) => $callback())
+            ->byDefault();
+
+        $this->realpathCache = new RealpathCache(
+            $this->wrappedStreamHandler,
+            $this->canonicaliser,
+            $this->realpathCachePool,
+            cacheNonExistentFiles: true,
+            asVirtualFilesystem: false
+        );
+    }
+
+    public function testCacheRealpathCanCacheARealpath(): void
+    {
+        $this->realpathCache = new RealpathCache(
+            $this->wrappedStreamHandler,
+            $this->canonicaliser,
+            new ArrayAdapter(),
+            cacheNonExistentFiles: true,
+            asVirtualFilesystem: false
+        );
+
+        $this->realpathCache->cacheRealpath(
+            canonicalPath: '/my/custom/canonical/path',
+            realpath: '/my/custom/real/path'
+        );
+
+        static::assertSame(
+            '/my/custom/real/path',
+            $this->realpathCache->getRealpath('/my/custom/canonical/path')
+        );
+        static::assertSame(
+            '/my/custom/real/path',
+            $this->realpathCache->getRealpath('/my/custom/real/path')
+        );
+        static::assertEquals(
+            [
+                'realpath' => '/my/custom/real/path',
+            ],
+            $this->realpathCache->getRealpathCacheEntry(
+                '/my/custom/canonical/path',
+                followSymlinks: true
+            )
+        );
+    }
+
+    public function testGetRealpathCachesNonExistentFileWhenEnabled(): void
+    {
+        $this->realpathCache = new RealpathCache(
+            $this->wrappedStreamHandler,
+            $this->canonicaliser,
+            new ArrayAdapter(),
+            cacheNonExistentFiles: true,
+            asVirtualFilesystem: false
+        );
+
+        $path = '/my/non/existent/path';
+
+        static::assertNull($this->realpathCache->getRealpath($path));
+        static::assertEquals(
+            ['exists' => false],
+            $this->realpathCache->getRealpathCacheEntry($path, followSymlinks: true)
+        );
+    }
+
+    public function testGetRealpathDoesNotCacheNonExistentFileWhenDisabled(): void
+    {
+        $path = '/my/non/existent/path';
+        $this->realpathCache = new RealpathCache(
+            $this->wrappedStreamHandler,
+            $this->canonicaliser,
+            new ArrayAdapter(),
+            cacheNonExistentFiles: false, // Disable caching of non-existent files.
+            asVirtualFilesystem: false
+        );
+
+        static::assertNull($this->realpathCache->getRealpath($path));
+        static::assertNull($this->realpathCache->getRealpathCacheEntry($path, followSymlinks: true));
+    }
+
+    public function testPersistRealpathCachePersistsBackingStore(): void
+    {
+        $this->realpathCachePool->expects()
+            ->commit()
+            ->once();
+
+        $this->realpathCache->persistRealpathCache();
+    }
+}

--- a/tests/Unit/FsCache/Stat/StatCacheTest.php
+++ b/tests/Unit/FsCache/Stat/StatCacheTest.php
@@ -1,0 +1,961 @@
+<?php
+
+/*
+ * Nytris Boost
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\Tests\Unit\FsCache\Stat;
+
+use Asmblah\PhpCodeShift\Shifter\Stream\Handler\StreamHandlerInterface;
+use Asmblah\PhpCodeShift\Shifter\Stream\Native\StreamWrapperInterface;
+use LogicException;
+use Mockery;
+use Mockery\MockInterface;
+use Nytris\Boost\Environment\EnvironmentInterface;
+use Nytris\Boost\FsCache\CanonicaliserInterface;
+use Nytris\Boost\FsCache\Realpath\RealpathCacheInterface;
+use Nytris\Boost\FsCache\Stat\StatCache;
+use Nytris\Boost\FsCache\Stat\StatCacheInterface;
+use Nytris\Boost\Tests\AbstractTestCase;
+use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
+
+/**
+ * Class StatCacheTest.
+ *
+ * @phpstan-import-type MultipleStatCacheStorage from StatCacheInterface
+ * @phpstan-import-type StatCacheEntry from StatCacheInterface
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class StatCacheTest extends AbstractTestCase
+{
+    private MockInterface&CanonicaliserInterface $canonicaliser;
+    private MockInterface&EnvironmentInterface $environment;
+    private MockInterface&RealpathCacheInterface $realpathCache;
+    private StatCache $statCache;
+    private MockInterface&CacheItemPoolInterface $statCachePool;
+    private MockInterface&CacheItemInterface $statCachePoolItem;
+    private MockInterface&StreamHandlerInterface $wrappedStreamHandler;
+
+    public function setUp(): void
+    {
+        $this->canonicaliser = mock(CanonicaliserInterface::class);
+        $this->environment = mock(EnvironmentInterface::class, [
+            'getStartTime' => 1725558258,
+        ]);
+        $this->realpathCache = mock(RealpathCacheInterface::class);
+        $this->statCachePool = mock(CacheItemPoolInterface::class);
+        $this->statCachePoolItem = mock(CacheItemInterface::class);
+        $this->wrappedStreamHandler = mock(StreamHandlerInterface::class);
+
+        $this->canonicaliser->allows('canonicalise')
+            ->andReturnArg(0)
+            ->byDefault();
+        $this->canonicaliser->allows('canonicaliseCacheKey')
+            ->andReturnUsing(fn (string $key) => 'canonicalised--' . preg_replace('#\W#', '_', $key))
+            ->byDefault();
+
+        $this->wrappedStreamHandler->allows('unwrapped')
+            ->andReturnUsing(fn (callable $callback) => $callback())
+            ->byDefault();
+
+        $this->statCache = new StatCache(
+            $this->wrappedStreamHandler,
+            $this->environment,
+            $this->canonicaliser,
+            $this->realpathCache,
+            statPreloadCachePool: null,
+            statCachePool: $this->statCachePool,
+            asVirtualFilesystem: false
+        );
+    }
+
+    public function testConstructorLoadsInMemoryCacheFromPreloadPoolWhenProvided(): void
+    {
+        $preloadCachePool = mock(CacheItemPoolInterface::class);
+        $includePreloadItem = mock(CacheItemInterface::class, [
+            'get' => [
+                '/my/first/path' => ['size' => 124],
+                '/my/second/path' => ['size' => 457],
+            ],
+            'isHit' => true,
+        ]);
+        $nonIncludePreloadItem = mock(CacheItemInterface::class, [
+            'get' => [
+                '/my/first/path' => ['size' => 123],
+                '/my/second/path' => ['size' => 456],
+            ],
+            'isHit' => true,
+        ]);
+
+        $preloadCachePool->expects()
+            ->getItem(StatCacheInterface::INCLUDE_PRELOAD_CACHE_KEY)
+            ->andReturn($includePreloadItem)
+            ->once();
+        $preloadCachePool->expects()
+            ->getItem(StatCacheInterface::NON_INCLUDE_PRELOAD_CACHE_KEY)
+            ->andReturn($nonIncludePreloadItem)
+            ->once();
+
+        $this->statCache = new StatCache(
+            $this->wrappedStreamHandler,
+            $this->environment,
+            $this->canonicaliser,
+            $this->realpathCache,
+            statPreloadCachePool: $preloadCachePool,
+            statCachePool: $this->statCachePool,
+            asVirtualFilesystem: false
+        );
+
+        static::assertEquals(
+            [
+                'include' => [
+                    '/my/first/path' => ['size' => 124],
+                    '/my/second/path' => ['size' => 457],
+                ],
+                'non_include' => [
+                    '/my/first/path' => ['size' => 123],
+                    '/my/second/path' => ['size' => 456],
+                ],
+            ],
+            $this->statCache->getInMemoryEntryCache()
+        );
+    }
+
+    public function testGetPathStatReturnsStatWhenCachedInInMemoryCache(): void
+    {
+        $accessible = true;
+        $this->realpathCache->allows()
+            ->getCachedEventualPath('/my/path.php', true, $accessible)
+            ->andReturn('/my/canonical/path.php');
+        $this->statCache->setInMemoryCacheEntry('/my/canonical/path.php', isInclude: false, entry: [
+            'size' => 123,
+        ]);
+
+        static::assertEquals(
+            ['size' => 123],
+            $this->statCache->getPathStat('/my/path.php', false)
+        );
+    }
+
+    public function testGetPathStatReturnsStatWhenCachedInPsrBackingCache(): void
+    {
+        $accessible = true;
+        $this->realpathCache->allows()
+            ->getCachedEventualPath('/my/path.php', true, $accessible)
+            ->andReturn('/my/canonical/path.php');
+        $this->statCachePool->allows()
+            ->getItem('plain_canonicalised--_my_canonical_path_php')
+            ->andReturn($this->statCachePoolItem);
+        $this->statCachePoolItem->allows()
+            ->get()
+            ->andReturn(['size' => 123]);
+        $this->statCachePoolItem->allows()
+            ->isHit()
+            ->andReturnTrue();
+
+        static::assertEquals(
+            ['size' => 123],
+            $this->statCache->getPathStat('/my/path.php', false)
+        );
+    }
+
+    public function testGetPathStatReturnsNullWhenNotCachedAndNonExistent(): void
+    {
+        $accessible = true;
+        $this->realpathCache->allows()
+            ->getCachedEventualPath('/my/path.php', true, $accessible)
+            ->andReturn('/my/canonical/path.php');
+        $this->statCachePool->allows()
+            ->getItem('plain_canonicalised--_my_canonical_path_php')
+            ->andReturn($this->statCachePoolItem);
+        $this->statCachePoolItem->allows()
+            ->isHit()
+            ->andReturnFalse();
+        $this->wrappedStreamHandler->allows()
+            ->urlStat('/my/path.php', 2)
+            ->andReturnFalse();
+
+        static::assertNull($this->statCache->getPathStat('/my/path.php', false));
+    }
+
+    public function testGetStreamStatReturnsStatCachedInInMemoryCache(): void
+    {
+        $streamWrapper = mock(StreamWrapperInterface::class);
+        $streamWrapper->allows()
+            ->getOpenPath()
+            ->andReturn('/my/file.php');
+        $streamWrapper->allows()
+            ->isInclude()
+            ->andReturnFalse();
+        $accessible = true;
+        $this->realpathCache->allows()
+            ->getCachedEventualPath('/my/file.php', true, $accessible)
+            ->andReturn('/my/real/file.php');
+        $this->statCache->setInMemoryCacheEntry('/my/real/file.php', isInclude: false, entry: [
+            'size' => 1000,
+        ]);
+
+        static::assertEquals(['size' => 1000], $this->statCache->getStreamStat($streamWrapper));
+    }
+
+    public function testGetStreamStatReturnsStatCachedInPsrBackingCache(): void
+    {
+        $streamWrapper = mock(StreamWrapperInterface::class);
+        $streamWrapper->allows()
+            ->getOpenPath()
+            ->andReturn('/my/file.php');
+        $streamWrapper->allows()
+            ->isInclude()
+            ->andReturnFalse();
+        $accessible = true;
+        $this->realpathCache->allows()
+            ->getCachedEventualPath('/my/file.php', true, $accessible)
+            ->andReturn('/my/real/file.php');
+        $this->statCachePool->allows()
+            ->getItem('plain_canonicalised--_my_real_file_php')
+            ->andReturn($this->statCachePoolItem);
+        $this->statCachePoolItem->allows()
+            ->get()
+            ->andReturn(['size' => 1000]);
+        $this->statCachePoolItem->allows()
+            ->isHit()
+            ->andReturnTrue();
+
+        static::assertEquals(['size' => 1000], $this->statCache->getStreamStat($streamWrapper));
+    }
+
+    public function testInvalidateClearsInMemoryCaches(): void
+    {
+        $this->statCachePool->allows('clear');
+        $this->statCache->setInMemoryCacheEntry('/my/real/path', isInclude: false, entry: ['size' => 123]);
+        $this->statCache->setInMemoryCacheEntry('/my/real/path', isInclude: true, entry: ['size' => 124]);
+
+        $this->statCache->invalidate();
+
+        $inMemoryCache = $this->statCache->getInMemoryEntryCache();
+        static::assertEquals([], $inMemoryCache['non_include']);
+        static::assertEquals([], $inMemoryCache['include']);
+    }
+
+    public function testInvalidateClearsPsrBackingCache(): void
+    {
+        $this->statCachePool->expects()
+            ->clear()
+            ->once();
+
+        $this->statCache->invalidate();
+    }
+
+    public function testInvalidatePathClearsCanonicalAndEventualEntriesFromBackingCache(): void
+    {
+        $this->canonicaliser->expects()->canonicalise('/my/path')
+            ->andReturn('/my/canonical/path');
+        $this->realpathCache->expects()->getCachedEventualPath('/my/path')
+            ->andReturn('/my/real/path');
+
+        $this->statCachePool->expects()
+            ->deleteItem('plain_canonicalised--_my_canonical_path')
+            ->once();
+        $this->statCachePool->expects()
+            ->deleteItem('include_canonicalised--_my_canonical_path')
+            ->once();
+        $this->statCachePool->expects()
+            ->deleteItem('plain_canonicalised--_my_real_path')
+            ->once();
+        $this->statCachePool->expects()
+            ->deleteItem('include_canonicalised--_my_real_path')
+            ->once();
+
+        $this->statCache->invalidatePath('/my/path');
+    }
+
+    public function testIsDirectoryReturnsTrueWhenPathIsCachedAsADirectoryInInMemoryCache(): void
+    {
+        $this->statCache->setInMemoryCacheEntry('/my/canonical/dir', isInclude: false, entry: [
+            'mode' => 0040755, // Directory mode.
+        ]);
+        $accessible = true;
+        $this->realpathCache->allows()
+            ->getCachedEventualPath('/my/dir', true, $accessible)
+            ->andReturn('/my/canonical/dir');
+
+        static::assertTrue($this->statCache->isDirectory('/my/dir'));
+    }
+
+    public function testIsDirectoryReturnsTrueWhenPathIsCachedAsADirectoryInPsrBackingCache(): void
+    {
+        $this->statCachePool->allows()
+            ->getItem('plain_canonicalised--_my_canonical_dir')
+            ->andReturn($this->statCachePoolItem);
+        $this->statCachePoolItem->allows()
+            ->get()
+            // Directory mode.
+            ->andReturn(['mode' => 0040755]);
+        $this->statCachePoolItem->allows()
+            ->isHit()
+            ->andReturnTrue();
+        $accessible = true;
+        $this->realpathCache->allows()
+            ->getCachedEventualPath('/my/dir', true, $accessible)
+            ->andReturn('/my/canonical/dir');
+
+        static::assertTrue($this->statCache->isDirectory('/my/dir'));
+    }
+
+    public function testIsDirectoryReturnsFalseWhenPathIsCachedAsAFileInInMemoryCache(): void
+    {
+        $this->statCache->setInMemoryCacheEntry('/my/canonical/dir', isInclude: false, entry: [
+            'mode' => 0100644, // Ordinary file mode.
+        ]);
+        $accessible = true;
+        $this->realpathCache->allows()
+            ->getCachedEventualPath('/my/dir', true, $accessible)
+            ->andReturn('/my/canonical/dir');
+
+        static::assertFalse($this->statCache->isDirectory('/my/dir'));
+    }
+
+    public function testIsDirectoryReturnsFalseWhenPathIsCachedAsAFileInPsrBackingCache(): void
+    {
+        $this->statCachePool->allows()
+            ->getItem('plain_canonicalised--_my_canonical_dir')
+            ->andReturn($this->statCachePoolItem);
+        $this->statCachePoolItem->allows()
+            ->get()
+            // Ordinary file mode.
+            ->andReturn(['mode' => 0100644]);
+        $this->statCachePoolItem->allows()
+            ->isHit()
+            ->andReturnTrue();
+        $accessible = true;
+        $this->realpathCache->allows()
+            ->getCachedEventualPath('/my/dir', true, $accessible)
+            ->andReturn('/my/canonical/dir');
+
+        static::assertFalse($this->statCache->isDirectory('/my/dir'));
+    }
+
+    public function testIsPathCachedAsExistentReturnsTrueWhenSoInInMemoryCache(): void
+    {
+        $accessible = true;
+        $this->realpathCache->allows()
+            ->getCachedEventualPath('/my/canonical/path/to/my_module.php', true, $accessible)
+            ->andReturn('/my/real/path/to/my_module.php');
+        $this->statCache->setInMemoryCacheEntry('/my/real/path/to/my_module.php', isInclude: false, entry: [
+            'size' => 123,
+        ]);
+
+        static::assertTrue($this->statCache->isPathCachedAsExistent('/my/canonical/path/to/my_module.php'));
+    }
+
+    public function testIsPathCachedAsExistentReturnsTrueWhenSoInPsrBackingCache(): void
+    {
+        $accessible = true;
+        $this->realpathCache->allows()
+            ->getCachedEventualPath('/my/canonical/path/to/my_module.php', true, $accessible)
+            ->andReturn('/my/real/path/to/my_module.php');
+        $this->statCachePool->allows()
+            ->getItem('plain_canonicalised--_my_real_path_to_my_module_php')
+            ->andReturn($this->statCachePoolItem);
+        $this->statCachePoolItem->allows()
+            ->get()
+            ->andReturn(['my' => 'stat']);
+        $this->statCachePoolItem->allows()
+            ->isHit()
+            ->andReturnTrue();
+
+        static::assertTrue($this->statCache->isPathCachedAsExistent('/my/canonical/path/to/my_module.php'));
+    }
+
+    public function testIsPathCachedAsExistentReturnsFalseWhenSo(): void
+    {
+        $accessible = true;
+        $this->realpathCache->allows()
+            ->getCachedEventualPath('/my/canonical/path/to/my_module.php', true, $accessible)
+            ->andReturn('/my/real/path/to/my_module.php');
+        $this->statCachePool->allows()
+            ->getItem('plain_canonicalised--_my_real_path_to_my_module_php')
+            ->andReturn($this->statCachePoolItem);
+        $this->statCachePoolItem->allows()
+            ->isHit()
+            ->andReturnFalse();
+
+        static::assertFalse($this->statCache->isPathCachedAsExistent('/my/canonical/path/to/my_module.php'));
+    }
+
+    public function testPersistStatCacheCommitsPsrBackingCache(): void
+    {
+        $this->statCachePool->expects()
+            ->commit()
+            ->once();
+
+        $this->statCache->persistStatCache();
+    }
+
+    public function testPopulateStatWithSizeUpdatesIncludeStatSizeInBothCachesWhenStatIsCached(): void
+    {
+        $cachedStat = ['size' => 1024];
+        $this->statCache->setInMemoryCacheEntry('/my/real/path.php', isInclude: true, entry: $cachedStat);
+        $this->statCachePoolItem->allows()
+            ->get()
+            ->andReturn($cachedStat);
+        $this->statCachePoolItem->allows()
+            ->isHit()
+            ->andReturnTrue();
+        $this->statCachePool->allows()
+            ->getItem('include_canonicalised--_my_real_path_php')
+            ->andReturn($this->statCachePoolItem);
+
+        $this->statCachePoolItem->expects()
+            ->set(['size' => 2048, 7 => 2048])
+            ->once()
+            ->andReturnSelf();
+        $this->statCachePool->expects()
+            ->saveDeferred($this->statCachePoolItem)
+            ->once()
+            ->andReturnTrue();
+
+        $this->statCache->populateStatWithSize('/my/real/path.php', 2048, isInclude: true);
+
+        $inMemoryEntryCache = $this->statCache->getInMemoryEntryCache();
+        static::assertEquals(
+            ['size' => 2048, 7 => 2048],
+            $inMemoryEntryCache['include']['/my/real/path.php']
+        );
+    }
+
+    public function testPopulateStatWithSizeUpdatesNonIncludeStatSizeInBothCachesWhenStatIsCached(): void
+    {
+        $cachedStat = ['size' => 1024];
+        $this->statCache->setInMemoryCacheEntry('/my/real/path.php', isInclude: false, entry: $cachedStat);
+        $this->statCachePoolItem->allows()
+            ->get()
+            ->andReturn($cachedStat);
+        $this->statCachePoolItem->allows()
+            ->isHit()
+            ->andReturnTrue();
+        $this->statCachePool->allows()
+            ->getItem('plain_canonicalised--_my_real_path_php')
+            ->andReturn($this->statCachePoolItem);
+
+        $this->statCachePoolItem->expects()
+            ->set(['size' => 2048, 7 => 2048])
+            ->once()
+            ->andReturnSelf();
+        $this->statCachePool->expects()
+            ->saveDeferred($this->statCachePoolItem)
+            ->once()
+            ->andReturnTrue();
+
+        $this->statCache->populateStatWithSize('/my/real/path.php', 2048, isInclude: false);
+
+        $inMemoryEntryCache = $this->statCache->getInMemoryEntryCache();
+        static::assertEquals(
+            ['size' => 2048, 7 => 2048],
+            $inMemoryEntryCache['non_include']['/my/real/path.php']
+        );
+    }
+
+    public function testPopulateStatWithSizeCopiesNonIncludeStatWhenIncludeNotCached(): void
+    {
+        $accessible = true;
+        $this->realpathCache->allows()
+            ->getCachedEventualPath('/my/real/path.php', true, $accessible)
+            ->andReturn('/my/real/path.php');
+        // Non-include cache entry exists but no include cache entry.
+        $cachedNonIncludeStat = $this->statCache->statToSynthetic([
+            'mode' => 0100777,
+            'uid' => 10,
+            'gid' => 20,
+            'size' => 1024,
+            'atime' => 1725558258,
+            'mtime' => 1725558258,
+            'ctime' => 1725558258,
+        ]);
+        $this->statCache->setInMemoryCacheEntry('/my/real/path.php', isInclude: false, entry: $cachedNonIncludeStat);
+        // When we attempt to get the include stat, it is not found.
+        $this->statCachePool->allows()
+            ->getItem('include_canonicalised--_my_real_path_php')
+            ->andReturn($this->statCachePoolItem);
+        $this->statCachePoolItem->allows()
+            ->isHit()
+            ->andReturnFalse();
+
+        $this->statCachePoolItem->expects()
+            ->set($this->statCache->statToSynthetic([
+                'mode' => 0100777,
+                'uid' => 10,
+                'gid' => 20,
+                'size' => 2048,
+                7 => 2048,
+                'atime' => 1725558258,
+                'mtime' => 1725558258,
+                'ctime' => 1725558258,
+            ]))
+            ->once()
+            ->andReturnSelf();
+        $this->statCachePool->expects()
+            ->saveDeferred($this->statCachePoolItem)
+            ->once()
+            ->andReturnTrue();
+
+        $this->statCache->populateStatWithSize('/my/real/path.php', 2048, isInclude: true);
+
+        $stat = $this->statCache->getInMemoryEntryCache()['include']['/my/real/path.php'];
+        static::assertSame(2048, $stat['size']);
+        static::assertSame(2048, $stat[7]);
+    }
+
+    public function testPopulateStatWithSizeThrowsExceptionWhenStatNotCachedAndNotInVirtualFilesystemMode(): void
+    {
+        $accessible = true;
+        $this->realpathCache->allows()
+            ->getCachedEventualPath('/my/real/path.php', true, $accessible)
+            ->andReturn('/my/real/path.php');
+        $this->statCachePool->allows()
+            ->getItem('include_canonicalised--_my_real_path_php')
+            ->andReturn($this->statCachePoolItem);
+        $this->statCachePool->allows()
+            ->getItem('plain_canonicalised--_my_real_path_php')
+            ->andReturn($this->statCachePoolItem);
+        $this->statCachePoolItem->allows()
+            ->isHit()
+            ->andReturnFalse();
+        $this->wrappedStreamHandler->allows()
+            ->urlStat('/my/real/path.php', 2)
+            ->andReturnFalse();
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Cannot stat original realpath "/my/real/path.php"');
+
+        $this->statCache->populateStatWithSize('/my/real/path.php', 1234, isInclude: true);
+    }
+
+    public function testPopulateStatWithSizeSynthesisesStatWhenNotCachedAndInVirtualFilesystemMode(): void
+    {
+        $this->statCache = new StatCache(
+            $this->wrappedStreamHandler,
+            $this->environment,
+            $this->canonicaliser,
+            $this->realpathCache,
+            statPreloadCachePool: null,
+            statCachePool: $this->statCachePool,
+            asVirtualFilesystem: true
+        );
+        $accessible = true;
+        $this->realpathCache->allows()
+            ->getCachedEventualPath('/my/real/path.php', true, $accessible)
+            ->andReturn('/my/real/path.php');
+        $this->statCachePool->allows()
+            ->getItem('include_canonicalised--_my_real_path_php')
+            ->andReturn($this->statCachePoolItem);
+        $this->statCachePool->allows()
+            ->getItem('plain_canonicalised--_my_real_path_php')
+            ->andReturn($this->statCachePoolItem);
+        $this->statCachePoolItem->allows()
+            ->isHit()
+            ->andReturnFalse();
+        $this->wrappedStreamHandler->allows()
+            ->urlStat('/my/real/path.php', 2)
+            ->andReturnFalse();
+
+        $this->statCachePoolItem->expects()
+            ->set($this->statCache->statToSynthetic([
+                'mode' => 0100777,
+                'uid' => 0,
+                'gid' => 0,
+                'size' => 1234,
+                7 => 1234,
+                'atime' => 1725558248,
+                'mtime' => 1725558248,
+                'ctime' => 1725558248,
+            ]))
+            ->once()
+            ->andReturnSelf();
+        $this->statCachePool->expects()
+            ->saveDeferred($this->statCachePoolItem)
+            ->once()
+            ->andReturnTrue();
+
+        $this->statCache->populateStatWithSize('/my/real/path.php', 1234, isInclude: true);
+    }
+
+    /**
+     * @param string $path
+     * @param bool $isInclude
+     * @param StatCacheEntry $entry
+     * @param MultipleStatCacheStorage $expectedCache
+     * @dataProvider setInMemoryCacheEntryProvider
+     */
+    public function testSetInMemoryCacheEntry(
+        string $path,
+        bool $isInclude,
+        array $entry,
+        array $expectedCache
+    ): void {
+        $this->statCache->setInMemoryCacheEntry($path, $isInclude, $entry);
+
+        static::assertEquals($expectedCache, $this->statCache->getInMemoryEntryCache());
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    public static function setInMemoryCacheEntryProvider(): array
+    {
+        return [
+            'non-include path' => [
+                'path' => '/my/non/include/path.php',
+                'isInclude' => false,
+                'entry' => ['size' => 100],
+                'expectedCache' => [
+                    'include' => [],
+                    'non_include' => [
+                        '/my/non/include/path.php' => ['size' => 100],
+                    ],
+                ],
+            ],
+            'include path' => [
+                'path' => '/my/include/path.php',
+                'isInclude' => true,
+                'entry' => ['size' => 200],
+                'expectedCache' => [
+                    'include' => [
+                        '/my/include/path.php' => ['size' => 200],
+                    ],
+                    'non_include' => [],
+                ],
+            ],
+            'multiple entries' => [
+                'path' => '/my/first/path.php',
+                'isInclude' => true,
+                'entry' => ['size' => 300],
+                'expectedCache' => [
+                    'include' => [
+                        '/my/first/path.php' => ['size' => 300],
+                    ],
+                    'non_include' => [],
+                ],
+            ],
+            'override existing' => [
+                'path' => '/my/path.php',
+                'isInclude' => false,
+                'entry' => ['size' => 400],
+                'expectedCache' => [
+                    'include' => [],
+                    'non_include' => [
+                        '/my/path.php' => ['size' => 400],
+                    ],
+                ],
+            ],
+        ];
+    }
+
+    public function testStatToSyntheticReturnsCorrectSyntheticStat(): void
+    {
+        $syntheticStat = $this->statCache->statToSynthetic([
+            'dev' => 2049,
+            'ino' => 1234567,
+            'mode' => 0100755,
+            'nlink' => 1,
+            'uid' => 1000,
+            'gid' => 1000,
+            'rdev' => 0,
+            'size' => 1024,
+            'atime' => 1633024800,
+            'mtime' => 1633024801,
+            'ctime' => 1633024802,
+            'blksize' => 4096,
+            'blocks' => 8,
+        ]);
+
+        static::assertEquals(
+            [
+                'dev' => 0,
+                'ino' => 0,
+                'mode' => 0100755,
+                'nlink' => 0,
+                'uid' => 1000,
+                'gid' => 1000,
+                'rdev' => 0,
+                'size' => 1024,
+                'atime' => 1633024800,
+                'mtime' => 1633024801,
+                'ctime' => 1633024802,
+                'blksize' => -1,
+                'blocks' => -1,
+
+                // Stat values are also available under indexed keys.
+                0 => 0,
+                1 => 0,
+                2 => 0100755,
+                3 => 0,
+                4 => 1000,
+                5 => 1000,
+                6 => 0,
+                7 => 1024,
+                8 => 1633024800,
+                9 => 1633024801,
+                10 => 1633024802,
+                11 => -1,
+                12 => -1,
+            ],
+            $syntheticStat
+        );
+    }
+
+    public function testStatToSyntheticCorrectlyHandlesEmptyStat(): void
+    {
+        $syntheticStat = $this->statCache->statToSynthetic([
+            'dev' => 2049,
+            'ino' => 1234567,
+            'mode' => 0100755,
+            'nlink' => 1,
+            'uid' => 1000,
+            'gid' => 1000,
+            'rdev' => 0,
+            'size' => 1024,
+            'atime' => 1633024800,
+            'mtime' => 1633024801,
+            'ctime' => 1633024802,
+            'blksize' => 4096,
+            'blocks' => 8,
+        ]);
+
+        static::assertEquals(
+            [
+                'dev' => 0,
+                'ino' => 0,
+                'mode' => 0100755,
+                'nlink' => 0,
+                'uid' => 1000,
+                'gid' => 1000,
+                'rdev' => 0,
+                'size' => 1024,
+                'atime' => 1633024800,
+                'mtime' => 1633024801,
+                'ctime' => 1633024802,
+                'blksize' => -1,
+                'blocks' => -1,
+
+                // Stat values are also available under indexed keys.
+                0 => 0,
+                1 => 0,
+                2 => 0100755,
+                3 => 0,
+                4 => 1000,
+                5 => 1000,
+                6 => 0,
+                7 => 1024,
+                8 => 1633024800,
+                9 => 1633024801,
+                10 => 1633024802,
+                11 => -1,
+                12 => -1,
+            ],
+            $syntheticStat
+        );
+    }
+
+    public function testSynthesiseStatSuccessfullySynthesisesStat(): void
+    {
+        $this->statCachePool->allows()
+            ->getItem('plain_canonicalised--_path_to_file')
+            ->andReturn($this->statCachePoolItem);
+        $this->statCachePoolItem->allows()
+            ->isHit()
+            ->andReturnFalse();
+        $this->statCache = new StatCache(
+            $this->wrappedStreamHandler,
+            $this->environment,
+            $this->canonicaliser,
+            $this->realpathCache,
+            null,
+            $this->statCachePool,
+            asVirtualFilesystem: true
+        );
+
+        // Expect the cache to be set with the generated synthetic stat
+        $this->statCachePoolItem->expects()
+            ->set(Mockery::subset([
+                'mode' => (0100000 | 0777), // Regular file with mode 0777.
+                'size' => 100,
+                'atime' => 1725558258 - 10,
+                'mtime' => 1725558258 - 10,
+                'ctime' => 1725558258 - 10,
+            ]))
+            ->once();
+        $this->statCachePool->expects()
+            ->saveDeferred($this->statCachePoolItem)
+            ->once();
+
+        $this->statCache->synthesiseStat('/path/to/file', isInclude: false, isDir: false, mode: 0777, size: 100);
+    }
+
+    public function testSynthesiseStatThrowsExceptionWhenNotVirtualFilesystem(): void
+    {
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Cannot use fully synthetic stats outside of a virtual filesystem');
+
+        $this->statCache->synthesiseStat('/path/to/file', isInclude: false, isDir: false, mode: 0777, size: 100);
+    }
+
+    public function testSynthesiseStatThrowsExceptionIfSyntheticStatAlreadyExists(): void
+    {
+        $this->statCachePoolItem->allows()
+            ->isHit()
+            ->andReturnTrue();
+        $this->statCachePool->allows()
+            ->getItem('plain_canonicalised--_path_to_file')
+            ->andReturn($this->statCachePoolItem);
+        $this->statCache = new StatCache(
+            $this->wrappedStreamHandler,
+            $this->environment,
+            $this->canonicaliser,
+            $this->realpathCache,
+            null,
+            $this->statCachePool,
+            asVirtualFilesystem: true
+        );
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('Synthetic stat already exists for path "/path/to/file"');
+
+        $this->statCache->synthesiseStat('/path/to/file', isInclude: false, isDir: false, mode: 0777, size: 100);
+    }
+
+    public function testUpdateSyntheticStatUpdatesFieldsCorrectly(): void
+    {
+        $this->statCachePool->allows()
+            ->getItem('plain_canonicalised--_path_to_file')
+            ->andReturn($this->statCachePoolItem);
+        $this->statCache = new StatCache(
+            $this->wrappedStreamHandler,
+            $this->environment,
+            $this->canonicaliser,
+            $this->realpathCache,
+            null,
+            $this->statCachePool,
+            asVirtualFilesystem: true
+        );
+        $this->statCache->setInMemoryCacheEntry('/path/to/file', isInclude: false, entry: [
+            'dev' => 0,
+            'ino' => 0,
+            'mode' => 0100644, // Regular file, rw-r--r--.
+            'nlink' => 0,
+            'uid' => 0,
+            'gid' => 0,
+            'rdev' => 0,
+            'size' => 1234,
+            'atime' => 1609459200, // Jan 1, 2021.
+            'mtime' => 1609459200,
+            'ctime' => 1609459200,
+            'blksize' => -1,
+            'blocks' => -1,
+
+            0 => 0,
+            1 => 0,
+            2 => 0100644, // Regular file, rw-r--r--.
+            3 => 0,
+            4 => 0,
+            5 => 0,
+            6 => 0,
+            7 => 1234,
+            8 => 1609459200, // Jan 1, 2021.
+            9 => 1609459200,
+            10 => 1609459200,
+            11 => -1,
+            12 => -1,
+        ]);
+        $newSize = 5678;
+        $newMode = 0755; // Update permissions to rwxr-xr-x.
+        $newMtime = 1609462800; // Update modification time to 1 hour later.
+        $expectedNewStat = [
+            'dev' => 0,
+            'ino' => 0,
+            'mode' => 0100755,
+            'nlink' => 0,
+            'uid' => 0,
+            'gid' => 0,
+            'rdev' => 0,
+            'size' => 5678,
+            'atime' => 1609459200,
+            'mtime' => 1609462800,
+            'ctime' => 1609459200,
+            'blksize' => -1,
+            'blocks' => -1,
+
+            // Stat values are also available under indexed keys.
+            0 => 0,
+            1 => 0,
+            2 => 0100755,
+            3 => 0,
+            4 => 0,
+            5 => 0,
+            6 => 0,
+            7 => 5678,
+            8 => 1609459200,
+            9 => 1609462800,
+            10 => 1609459200,
+            11 => -1,
+            12 => -1,
+        ];
+
+        $this->statCachePoolItem->expects()
+            ->set($expectedNewStat)
+            ->once();
+        $this->statCachePool->expects()
+            ->saveDeferred($this->statCachePoolItem)
+            ->once();
+
+        $this->statCache->updateSyntheticStat(
+            '/path/to/file',
+            isInclude: false,
+            mode: $newMode,
+            size: $newSize,
+            modificationTime: $newMtime
+        );
+
+        static::assertEquals(
+            $expectedNewStat,
+            $this->statCache->getInMemoryEntryCache()['non_include']['/path/to/file']
+        );
+    }
+
+    public function testUpdateSyntheticStatThrowsExceptionIfNoSyntheticStatExists(): void
+    {
+        $this->statCachePool->allows()
+            ->getItem('plain_canonicalised--_path_to_nonexistent_file')
+            ->andReturn($this->statCachePoolItem);
+        $this->statCachePoolItem->allows()
+            ->isHit()
+            ->andReturnFalse();
+        $this->statCache = new StatCache(
+            $this->wrappedStreamHandler,
+            $this->environment,
+            $this->canonicaliser,
+            $this->realpathCache,
+            null,
+            $this->statCachePool,
+            asVirtualFilesystem: true
+        );
+
+        $this->expectException(LogicException::class);
+        $this->expectExceptionMessage('No synthetic stat exists for path "/path/to/nonexistent/file"');
+
+        $this->statCache->updateSyntheticStat(
+            '/path/to/nonexistent/file',
+            isInclude: false,
+            mode: 0755,
+            size: 5678
+        );
+    }
+}

--- a/tests/Unit/FsCache/Stream/Handler/FsCachingStreamHandlerTest.php
+++ b/tests/Unit/FsCache/Stream/Handler/FsCachingStreamHandlerTest.php
@@ -17,13 +17,14 @@ use Asmblah\PhpCodeShift\Shifter\Filter\FileFilter;
 use Asmblah\PhpCodeShift\Shifter\Stream\Handler\StreamHandlerInterface;
 use Asmblah\PhpCodeShift\Shifter\Stream\Native\StreamWrapperInterface;
 use Mockery\MockInterface;
+use Nytris\Boost\Environment\EnvironmentInterface;
 use Nytris\Boost\FsCache\CanonicaliserInterface;
 use Nytris\Boost\FsCache\Contents\ContentsCacheInterface;
+use Nytris\Boost\FsCache\Realpath\RealpathCacheInterface;
+use Nytris\Boost\FsCache\Stat\StatCacheInterface;
 use Nytris\Boost\FsCache\Stream\Handler\FsCachingStreamHandler;
 use Nytris\Boost\FsCache\Stream\Opener\StreamOpenerInterface;
 use Nytris\Boost\Tests\AbstractTestCase;
-use Psr\Cache\CacheItemInterface;
-use Psr\Cache\CacheItemPoolInterface;
 
 /**
  * Class FsCachingStreamHandlerTest.
@@ -34,12 +35,10 @@ class FsCachingStreamHandlerTest extends AbstractTestCase
 {
     private MockInterface&CanonicaliserInterface $canonicaliser;
     private MockInterface&ContentsCacheInterface $contentsCache;
+    private MockInterface&EnvironmentInterface $environment;
     private FsCachingStreamHandler $fsCachingStreamHandler;
-    private MockInterface&CacheItemPoolInterface $realpathCachePool;
-    private MockInterface&CacheItemInterface $realpathCachePoolItem;
-    private MockInterface&CacheItemPoolInterface $statCachePool;
-    private MockInterface&CacheItemInterface $statCacheItemForIncludes;
-    private MockInterface&CacheItemInterface $statCacheItemForNonIncludes;
+    private MockInterface&RealpathCacheInterface $realpathCache;
+    private MockInterface&StatCacheInterface $statCache;
     private MockInterface&StreamOpenerInterface $streamOpener;
     private MockInterface&StreamWrapperInterface $streamWrapper;
     private MockInterface&StreamHandlerInterface $wrappedStreamHandler;
@@ -48,32 +47,9 @@ class FsCachingStreamHandlerTest extends AbstractTestCase
     {
         $this->canonicaliser = mock(CanonicaliserInterface::class);
         $this->contentsCache = mock(ContentsCacheInterface::class);
-        $this->realpathCachePool = mock(CacheItemPoolInterface::class);
-        $this->realpathCachePoolItem = mock(CacheItemInterface::class, [
-            'get' => [
-                '/my/resolved/../path/to/my_module.php' => [
-                    'canonical' => '/my/path/to/my_module.php',
-                ],
-            ],
-            'isHit' => true,
-        ]);
-        $this->statCachePool = mock(CacheItemPoolInterface::class);
-        $this->statCacheItemForIncludes = mock(CacheItemInterface::class, [
-            'get' => [
-                '/my/path/to/my_module.php' => [
-                    'my_fake_include_stat' => 'yes',
-                ],
-            ],
-            'isHit' => true,
-        ]);
-        $this->statCacheItemForNonIncludes = mock(CacheItemInterface::class, [
-            'get' => [
-                '/my/file.txt' => [
-                    'my_fake_plain_stat' => 'yes',
-                ],
-            ],
-            'isHit' => true,
-        ]);
+        $this->environment = mock(EnvironmentInterface::class);
+        $this->realpathCache = mock(RealpathCacheInterface::class);
+        $this->statCache = mock(StatCacheInterface::class);
         $this->streamOpener = mock(StreamOpenerInterface::class);
         $this->streamWrapper = mock(StreamWrapperInterface::class);
         $this->wrappedStreamHandler = mock(StreamHandlerInterface::class);
@@ -82,147 +58,104 @@ class FsCachingStreamHandlerTest extends AbstractTestCase
             ->andReturnArg(0)
             ->byDefault();
 
-        $this->realpathCachePool->allows()
-            ->getItem('my_realpath_cache_key')
-            ->andReturn($this->realpathCachePoolItem)
-            ->byDefault();
-
-        $this->statCachePool->allows()
-            ->getItem('my_stat_cache_key_includes')
-            ->andReturn($this->statCacheItemForIncludes)
-            ->byDefault();
-
-        $this->statCachePool->allows()
-            ->getItem('my_stat_cache_key_plain')
-            ->andReturn($this->statCacheItemForNonIncludes)
-            ->byDefault();
-
         $this->wrappedStreamHandler->allows('unwrapped')
             ->andReturnUsing(fn (callable $callback) => $callback())
             ->byDefault();
 
         $this->fsCachingStreamHandler = new FsCachingStreamHandler(
             $this->wrappedStreamHandler,
+            $this->environment,
             $this->streamOpener,
-            $this->canonicaliser,
-            $this->realpathCachePool,
-            $this->statCachePool,
+            $this->realpathCache,
+            $this->statCache,
             $this->contentsCache,
-            realpathCacheKey: 'my_realpath_cache_key',
-            statCacheKey: 'my_stat_cache_key',
-            cacheNonExistentFiles: true,
-            pathFilter: new FileFilter('/my/**')
+            pathFilter: new FileFilter('/my/**'),
+            asVirtualFilesystem: false
         );
     }
 
-    public function testCacheRealpathCanCacheARealpath(): void
+    public function testCacheRealpathForwardsOntoRealpathCache(): void
     {
+        $this->realpathCache->expects()
+            ->cacheRealpath(
+                '/my/custom/canonical/path',
+                '/my/custom/real/path'
+            )
+            ->once();
+
         $this->fsCachingStreamHandler->cacheRealpath(
             canonicalPath: '/my/custom/canonical/path',
             realpath: '/my/custom/real/path'
         );
+    }
+
+    public function testGetRealpathForwardsOntoRealpathCache(): void
+    {
+        $this->realpathCache->allows()
+            ->getRealpath('/my/custom/canonical/path')
+            ->andReturn('/my/custom/real/path');
 
         static::assertSame(
             '/my/custom/real/path',
             $this->fsCachingStreamHandler->getRealpath('/my/custom/canonical/path')
         );
-        static::assertSame(
-            '/my/custom/real/path',
-            $this->fsCachingStreamHandler->getRealpath('/my/custom/real/path')
-        );
-        static::assertEquals(
-            [
-                'realpath' => '/my/custom/real/path',
-            ],
-            $this->fsCachingStreamHandler->getRealpathCacheEntry('/my/custom/canonical/path')
-        );
     }
 
-    public function testGetRealpathCachesNonExistentFileWhenEnabled(): void
+    public function testInvalidatePathInvalidatesSubCachesWhenMatchedByPathFilter(): void
     {
-        $path = '/my/non/existent/path';
+        $this->realpathCache->allows()
+            ->getCachedEventualPath('/my/canonical/path/to/my_file.txt')
+            ->andReturn('/my/real/path/to/my_file.txt');
 
-        static::assertNull($this->fsCachingStreamHandler->getRealpath($path));
-        static::assertEquals(
-            ['exists' => false],
-            $this->fsCachingStreamHandler->getRealpathCacheEntry($path)
-        );
-    }
-
-    public function testGetRealpathDoesNotCacheNonExistentFileWhenDisabled(): void
-    {
-        $path = '/my/non/existent/path';
-        $this->fsCachingStreamHandler = new FsCachingStreamHandler(
-            $this->wrappedStreamHandler,
-            $this->streamOpener,
-            $this->canonicaliser,
-            $this->realpathCachePool,
-            $this->statCachePool,
-            $this->contentsCache,
-            realpathCacheKey: 'my_realpath_cache_key',
-            statCacheKey: 'my_stat_cache_key',
-            cacheNonExistentFiles: false, // Disable caching of non-existent files.
-            pathFilter: new FileFilter('**')
-        );
-
-        static::assertNull($this->fsCachingStreamHandler->getRealpath($path));
-        static::assertNull($this->fsCachingStreamHandler->getRealpathCacheEntry($path));
-    }
-
-    public function testInvalidatePathInvalidatesContentsCacheWhenMatchedByPathFilter(): void
-    {
+        $this->realpathCache->expects()
+            ->invalidatePath('/my/canonical/path/to/my_file.txt')
+            ->once();
+        $this->statCache->expects()
+            ->invalidatePath('/my/canonical/path/to/my_file.txt')
+            ->once();
         $this->contentsCache->expects()
-            ->invalidatePath('/my/path/to/my_file.txt')
+            ->invalidatePath('/my/canonical/path/to/my_file.txt')
             ->once();
 
-        $this->fsCachingStreamHandler->invalidatePath('/my/path/to/my_file.txt');
+        $this->fsCachingStreamHandler->invalidatePath('/my/canonical/path/to/my_file.txt');
     }
 
-    public function testInvalidatePathDoesNotInvalidateContentsCacheWhenIgnoredByPathFilter(): void
+    public function testInvalidatePathDoesNotInvalidateSubCachesWhenIgnoredByPathFilter(): void
     {
+        $this->realpathCache->allows()
+            ->getCachedEventualPath('/your/canonical/path/to/your_file.txt')
+            ->andReturn('/your/real/path/to/your_file.txt');
+
+        $this->realpathCache->expects('invalidatePath')
+            ->never();
+        $this->statCache->expects('invalidatePath')
+            ->never();
         $this->contentsCache->expects('invalidatePath')
             ->never();
 
-        $this->fsCachingStreamHandler->invalidatePath('/your/path/to/my_file.txt');
+        $this->fsCachingStreamHandler->invalidatePath('/your/canonical/path/to/your_file.txt');
     }
 
-    public function testPersistStatCachePersistsBothStatTypeCachesWhenDirty(): void
+    public function testPersistStatCachePersistsStatCache(): void
     {
-        $this->statCacheItemForIncludes->expects('set')
+        $this->statCache->expects()
+            ->persistStatCache()
             ->once();
-        $this->statCacheItemForNonIncludes->expects('set')
-            ->once();
-        $this->statCachePool->expects()
-            ->saveDeferred($this->statCacheItemForIncludes)
-            ->once();
-        $this->statCachePool->expects()
-            ->saveDeferred($this->statCacheItemForNonIncludes)
-            ->once();
-
-        $this->fsCachingStreamHandler->invalidateCaches();
-        $this->fsCachingStreamHandler->persistStatCache();
-    }
-
-    public function testPersistStatCacheDoesNotPersistStatTypeCachesWhenClean(): void
-    {
-        $this->statCacheItemForIncludes->expects('set')
-            ->never();
-        $this->statCacheItemForNonIncludes->expects('set')
-            ->never();
-        $this->statCachePool->expects('saveDeferred')
-            ->never();
 
         $this->fsCachingStreamHandler->persistStatCache();
     }
 
     public function testStreamOpenForwardsToWrappedHandlerWhenIgnoredByPathFilter(): void
     {
+        $this->realpathCache->allows()
+            ->getEventualPath('/your/canonical/path/to/your_file.php')
+            ->andReturn('/your/real/path/to/your_file.php');
         $openedPath = null;
         $this->wrappedStreamHandler->allows()
             ->streamOpen(
                 $this->streamWrapper,
                 // Use `/your/**` path so that configured path filter is not matched.
-                '/your/path/to/my_file.php',
+                '/your/canonical/path/to/your_file.php',
                 'r',
                 0,
                 $openedPath
@@ -233,7 +166,7 @@ class FsCachingStreamHandlerTest extends AbstractTestCase
             ['resource' => 21, 'isInclude' => true],
             $this->fsCachingStreamHandler->streamOpen(
                 $this->streamWrapper,
-                '/your/path/to/my_file.php',
+                '/your/canonical/path/to/your_file.php',
                 'r',
                 0,
                 $openedPath
@@ -243,15 +176,17 @@ class FsCachingStreamHandlerTest extends AbstractTestCase
 
     public function testStreamOpenForwardsToStreamOpenerWhenMatchedByPathFilter(): void
     {
+        $this->realpathCache->allows()
+            ->getEventualPath('/my/canonical/path/to/my_file.php')
+            ->andReturn('/my/real/path/to/my_file.php');
         $openedPath = null;
         $this->streamOpener->allows()
             ->openStream(
                 $this->streamWrapper,
-                '/my/path/to/my_file.php',
+                '/my/real/path/to/my_file.php',
                 'r',
                 0,
-                $openedPath,
-                $this->fsCachingStreamHandler
+                $openedPath
             )
             ->andReturn(['resource' => 21, 'isInclude' => true]);
 
@@ -259,7 +194,7 @@ class FsCachingStreamHandlerTest extends AbstractTestCase
             ['resource' => 21, 'isInclude' => true],
             $this->fsCachingStreamHandler->streamOpen(
                 $this->streamWrapper,
-                '/my/path/to/my_file.php',
+                '/my/canonical/path/to/my_file.php',
                 'r',
                 0,
                 $openedPath
@@ -267,18 +202,17 @@ class FsCachingStreamHandlerTest extends AbstractTestCase
         );
     }
 
-    public function testStreamStatRetrievesACachedIncludeStat(): void
+    public function testStreamStatRetrievesACachedStat(): void
     {
         $this->streamWrapper->allows()
             ->getOpenPath()
-            ->andReturn('/my/path/to/my_module.php');
-        $this->streamWrapper->allows()
-            ->isInclude()
-            ->andReturnTrue();
-        $this->fsCachingStreamHandler->cacheRealpath(
-            canonicalPath: '/my/path/to/my_module.php',
-            realpath: '/my/path/to/my_module.php'
-        );
+            ->andReturn('/my/canonical/path/to/my_module.php');
+        $this->realpathCache->allows()
+            ->getEventualPath('/my/canonical/path/to/my_module.php')
+            ->andReturn('/my/real/path/to/my_module.php');
+        $this->statCache->allows()
+            ->getStreamStat($this->streamWrapper)
+            ->andReturn(['my_fake_include_stat' => 'yes']);
 
         static::assertEquals(
             ['my_fake_include_stat' => 'yes'],
@@ -286,73 +220,18 @@ class FsCachingStreamHandlerTest extends AbstractTestCase
         );
     }
 
-    public function testStreamStatDoesNotRetrieveACachedIncludeStatForPlainStream(): void
-    {
-        $this->streamWrapper->allows()
-            ->getOpenPath()
-            ->andReturn('/my/path/to/my_module.php');
-        $this->streamWrapper->allows()
-            ->isInclude()
-            ->andReturnFalse();
-        $this->fsCachingStreamHandler->cacheRealpath(
-            canonicalPath: '/my/path/to/my_module.php',
-            realpath: '/my/path/to/my_module.php'
-        );
-        $this->wrappedStreamHandler->allows()
-            ->streamStat($this->streamWrapper)
-            ->andReturnFalse();
-
-        static::assertFalse($this->fsCachingStreamHandler->streamStat($this->streamWrapper));
-    }
-
-    public function testStreamStatRetrievesACachedPlainStat(): void
-    {
-        $this->streamWrapper->allows()
-            ->getOpenPath()
-            ->andReturn('/my/file.txt');
-        $this->streamWrapper->allows()
-            ->isInclude()
-            ->andReturnFalse();
-        $this->fsCachingStreamHandler->cacheRealpath(
-            canonicalPath: '/my/file.txt',
-            realpath: '/my/file.txt'
-        );
-
-        static::assertEquals(
-            ['my_fake_plain_stat' => 'yes'],
-            $this->fsCachingStreamHandler->streamStat($this->streamWrapper)
-        );
-    }
-
-    public function testStreamStatDoesNotRetrieveACachedPlainStatForIncludeStream(): void
-    {
-        $this->streamWrapper->allows()
-            ->getOpenPath()
-            ->andReturn('/my/file.txt');
-        $this->streamWrapper->allows()
-            ->isInclude()
-            ->andReturnTrue();
-        $this->fsCachingStreamHandler->cacheRealpath(
-            canonicalPath: '/my/file.txt',
-            realpath: '/my/file.txt'
-        );
-        $this->wrappedStreamHandler->allows()
-            ->streamStat($this->streamWrapper)
-            ->andReturnFalse();
-
-        static::assertFalse($this->fsCachingStreamHandler->streamStat($this->streamWrapper));
-    }
-
     public function testUrlStatRetrievesACachedPlainStat(): void
     {
-        $this->fsCachingStreamHandler->cacheRealpath(
-            canonicalPath: '/my/file.txt',
-            realpath: '/my/file.txt'
-        );
+        $this->realpathCache->allows()
+            ->getEventualPath('/my/canonical/file.txt')
+            ->andReturn('/my/real/file.txt');
+        $this->statCache->allows()
+            ->getPathStat('/my/canonical/file.txt', false, false)
+            ->andReturn(['my_fake_plain_stat' => 'yes']);
 
         static::assertEquals(
             ['my_fake_plain_stat' => 'yes'],
-            $this->fsCachingStreamHandler->urlStat('/my/file.txt', 0)
+            $this->fsCachingStreamHandler->urlStat('/my/canonical/file.txt', 0)
         );
     }
 }

--- a/tests/Unit/FsCache/Stream/Handler/FsCachingStreamHandlerTest.php
+++ b/tests/Unit/FsCache/Stream/Handler/FsCachingStreamHandlerTest.php
@@ -13,10 +13,12 @@ declare(strict_types=1);
 
 namespace Nytris\Boost\Tests\Unit\FsCache\Stream\Handler;
 
+use Asmblah\PhpCodeShift\Shifter\Filter\FileFilter;
 use Asmblah\PhpCodeShift\Shifter\Stream\Handler\StreamHandlerInterface;
 use Asmblah\PhpCodeShift\Shifter\Stream\Native\StreamWrapperInterface;
 use Mockery\MockInterface;
 use Nytris\Boost\FsCache\CanonicaliserInterface;
+use Nytris\Boost\FsCache\Contents\ContentsCacheInterface;
 use Nytris\Boost\FsCache\Stream\Handler\FsCachingStreamHandler;
 use Nytris\Boost\Tests\AbstractTestCase;
 use Psr\Cache\CacheItemInterface;
@@ -30,6 +32,7 @@ use Psr\Cache\CacheItemPoolInterface;
 class FsCachingStreamHandlerTest extends AbstractTestCase
 {
     private MockInterface&CanonicaliserInterface $canonicaliser;
+    private MockInterface&ContentsCacheInterface $contentsCache;
     private FsCachingStreamHandler $fsCachingStreamHandler;
     private MockInterface&CacheItemPoolInterface $realpathCachePool;
     private MockInterface&CacheItemInterface $realpathCachePoolItem;
@@ -42,6 +45,7 @@ class FsCachingStreamHandlerTest extends AbstractTestCase
     public function setUp(): void
     {
         $this->canonicaliser = mock(CanonicaliserInterface::class);
+        $this->contentsCache = mock(ContentsCacheInterface::class);
         $this->realpathCachePool = mock(CacheItemPoolInterface::class);
         $this->realpathCachePoolItem = mock(CacheItemInterface::class, [
             'get' => [
@@ -99,8 +103,11 @@ class FsCachingStreamHandlerTest extends AbstractTestCase
             $this->canonicaliser,
             $this->realpathCachePool,
             $this->statCachePool,
+            $this->contentsCache,
             realpathCacheKey: 'my_realpath_cache_key',
-            statCacheKey: 'my_stat_cache_key'
+            statCacheKey: 'my_stat_cache_key',
+            cacheNonExistentFiles: true,
+            pathFilter: new FileFilter('*')
         );
     }
 
@@ -146,9 +153,11 @@ class FsCachingStreamHandlerTest extends AbstractTestCase
             $this->canonicaliser,
             $this->realpathCachePool,
             $this->statCachePool,
+            $this->contentsCache,
             realpathCacheKey: 'my_realpath_cache_key',
             statCacheKey: 'my_stat_cache_key',
-            cacheNonExistentFiles: false // Disable caching of non-existent files.
+            cacheNonExistentFiles: false, // Disable caching of non-existent files.
+            pathFilter: new FileFilter('*')
         );
 
         static::assertNull($this->fsCachingStreamHandler->getRealpath($path));

--- a/tests/Unit/FsCache/Stream/Opener/StreamOpenerTest.php
+++ b/tests/Unit/FsCache/Stream/Opener/StreamOpenerTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/*
+ * Nytris Boost
+ * Copyright (c) Dan Phillimore (asmblah)
+ * https://github.com/nytris/boost/
+ *
+ * Released under the MIT license.
+ * https://github.com/nytris/boost/raw/main/MIT-LICENSE.txt
+ */
+
+declare(strict_types=1);
+
+namespace Nytris\Boost\Tests\Unit\FsCache\Stream\Opener;
+
+use Asmblah\PhpCodeShift\Shifter\Stream\Handler\StreamHandlerInterface;
+use Asmblah\PhpCodeShift\Shifter\Stream\Native\StreamWrapperInterface;
+use Mockery\MockInterface;
+use Nytris\Boost\FsCache\CanonicaliserInterface;
+use Nytris\Boost\FsCache\Contents\ContentsCacheInterface;
+use Nytris\Boost\FsCache\Stream\Handler\FsCachingStreamHandlerInterface;
+use Nytris\Boost\FsCache\Stream\Opener\StreamOpener;
+use Nytris\Boost\Tests\AbstractTestCase;
+
+/**
+ * Class StreamOpenerTest.
+ *
+ * @author Dan Phillimore <dan@ovms.co>
+ */
+class StreamOpenerTest extends AbstractTestCase
+{
+    private MockInterface&CanonicaliserInterface $canonicaliser;
+    private MockInterface&ContentsCacheInterface $contentsCache;
+    private MockInterface&FsCachingStreamHandlerInterface $streamHandler;
+    private StreamOpener $streamOpener;
+    private MockInterface&StreamWrapperInterface $streamWrapper;
+    private MockInterface&StreamHandlerInterface $wrappedStreamHandler;
+
+    public function setUp(): void
+    {
+        $this->canonicaliser = mock(CanonicaliserInterface::class);
+        $this->contentsCache = mock(ContentsCacheInterface::class);
+        $this->streamHandler = mock(FsCachingStreamHandlerInterface::class);
+        $this->streamWrapper = mock(StreamWrapperInterface::class);
+        $this->wrappedStreamHandler = mock(StreamHandlerInterface::class);
+
+        $this->streamOpener = new StreamOpener(
+            $this->wrappedStreamHandler,
+            $this->canonicaliser,
+            $this->contentsCache
+        );
+    }
+
+    public function testOpenStreamInvalidatesCanonicalPathForWriteModes(): void
+    {
+        $this->canonicaliser->allows()
+            ->canonicalise('/my/uncanonical/path/to/my_file.txt')
+            ->andReturn('/my/canonical/path/to/my_file.txt');
+        $openedPath = null;
+        $this->wrappedStreamHandler->allows()
+            ->streamOpen(
+                $this->streamWrapper,
+                '/my/canonical/path/to/my_file.txt',
+                'r+',
+                0,
+                $openedPath
+            )
+            ->andReturn(['resource' => 21, 'isInclude' => false]);
+
+        $this->streamHandler->expects()
+            ->invalidatePath('/my/canonical/path/to/my_file.txt')
+            ->once();
+
+        $this->streamOpener->openStream(
+            $this->streamWrapper,
+            '/my/uncanonical/path/to/my_file.txt',
+            'r+',
+            0,
+            $openedPath,
+            $this->streamHandler
+        );
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -13,4 +13,5 @@ declare(strict_types=1);
 
 require_once __DIR__ . '/../vendor/autoload.php';
 
+Mockery::getConfiguration()->allowMockingNonExistentMethods(false);
 Mockery::globalHelpers();


### PR DESCRIPTION
- In addition to the realpath and stat caching, the contents of files may optionally also be cached in a PSR-6 cache.
- The in-memory realpath and stat caches may both optionally be preloaded from a readonly preload cache pool respectively.
- With the addition of contents caching, a virtual filesystem mode has been added which avoids the I/O of hitting the actual filesystem.